### PR TITLE
Update pac_parse.yy

### DIFF
--- a/src/pac_parse.yy
+++ b/src/pac_parse.yy
@@ -1089,5 +1089,6 @@ int yyerror(const char msg[])
 	fprintf(stderr, " (yychar=%d)", yychar);
 	fprintf(stderr, "\n");
 
+	delete[] msgbuf;
 	return 0;
         }


### PR DESCRIPTION
(error) Memory leak: msgbuf

NOTE: also reported in tracker.bro.org, viz. https://bro-tracker.atlassian.net/browse/BIT-1659

Found by https://github.com/bryongloden/cppcheck
