### PR TITLE
Force throw of out-of-bound during parsing of arrays

### DIFF
--- a/src/pac_array.cc
+++ b/src/pac_array.cc
@@ -609,31 +609,44 @@ void ArrayType::GenUntilCheck(Output *out_cc, Env *env,
 			new Expr(elem_input_var()->clone()));
 		}
 
-	out_cc->println("// Check &until(%s)", until_expr->orig());
-	out_cc->println("if ( %s )",
-		until_expr->EvalExpr(out_cc, &check_env));
-	out_cc->inc_indent();
-	out_cc->println("{");
-	if ( parsing_complete_var() )
-		{
-		out_cc->println("%s = true;",
-			env->LValue(parsing_complete_var()));
+		//if the array length is known, check for out-of-bound
+		if(env->Evaluated(arraylength_var())){
+			out_cc->println("if( t_%s__elem__dataptr + 1 > t_end_of_data || t_%s__elem__dataptr + 1 < t_%s__elem__dataptr )", value_var()->Name(), value_var()->Name(), value_var()->Name());
+			out_cc->inc_indent();
+			out_cc->println("{");
+			out_cc->println("// Handle out-of-bound condition");
+			out_cc->println("throw binpac::ExceptionOutOfBound(\"%s\",", elemtype_->DataTypeStr().c_str());
+			out_cc->println("	0, //current_data_pointer- t_begin_of_data+1");
+			out_cc->println(" 0); //(t_end_of_data) - (t_begin_of_data)");
+			out_cc->println("}");
+			out_cc->dec_indent();
+			SetBoundaryChecked();	// to evict double checking
 		}
+		//otherwise, check the until condition
+		else{
+			out_cc->println("// Check &until(%s)", until_expr->orig());
+			out_cc->println("if ( %s )",
+				until_expr->EvalExpr(out_cc, &check_env));
+			out_cc->inc_indent();
+			out_cc->println("{");
+			if ( parsing_complete_var() )
+				{
+				out_cc->println("%s = true;",
+					env->LValue(parsing_complete_var()));
+				}
 
-	if ( elemtype_->IsPointerType() )
-		{
-		if ( delete_elem )
-			elemtype_->GenCleanUpCode(out_cc, env);
-		else
-			out_cc->println("%s = 0;", env->LValue(elem_var()));
+			if ( elemtype_->IsPointerType() )
+				{
+				if ( delete_elem )
+					elemtype_->GenCleanUpCode(out_cc, env);
+				else
+					out_cc->println("%s = 0;", env->LValue(elem_var()));
+				}
+
+				out_cc->println("goto %s;", end_of_array_loop_label_.c_str());
+				out_cc->println("}");
+				out_cc->dec_indent();
 		}
-
-	out_cc->println("// Handle out-of-bound condition");
-	out_cc->println("throw binpac::ExceptionOutOfBound(\"%s\",", elemtype_->DataTypeStr().c_str());
-	out_cc->println("	0, //current_data_pointer- t_begin_of_data+1");
-	out_cc->println(" 0); //(t_end_of_data) - (t_begin_of_data)");
-	out_cc->println("}");
-	out_cc->dec_indent();
 	}
 
 void ArrayType::GenDynamicSize(Output *out_cc, Env *env,

--- a/src/pac_array.cc
+++ b/src/pac_array.cc
@@ -628,7 +628,10 @@ void ArrayType::GenUntilCheck(Output *out_cc, Env *env,
 			out_cc->println("%s = 0;", env->LValue(elem_var()));
 		}
 
-	out_cc->println("goto %s;", end_of_array_loop_label_.c_str());
+	out_cc->println("// Handle out-of-bound condition");
+	out_cc->println("throw binpac::ExceptionOutOfBound(\"%s\",", elemtype_->DataTypeStr().c_str());
+	out_cc->println("	0, //current_data_pointer- t_begin_of_data+1");
+	out_cc->println(" 0); //(t_end_of_data) - (t_begin_of_data)");
 	out_cc->println("}");
 	out_cc->dec_indent();
 	}

--- a/src/pac_array.cc
+++ b/src/pac_array.cc
@@ -609,21 +609,8 @@ void ArrayType::GenUntilCheck(Output *out_cc, Env *env,
 			new Expr(elem_input_var()->clone()));
 		}
 
-		//if the array length is known, check for out-of-bound
-		if(env->Evaluated(arraylength_var())){
-			out_cc->println("if( t_%s__elem__dataptr + 1 > t_end_of_data || t_%s__elem__dataptr + 1 < t_%s__elem__dataptr )", value_var()->Name(), value_var()->Name(), value_var()->Name());
-			out_cc->inc_indent();
-			out_cc->println("{");
-			out_cc->println("// Handle out-of-bound condition");
-			out_cc->println("throw binpac::ExceptionOutOfBound(\"%s\",", elemtype_->DataTypeStr().c_str());
-			out_cc->println("	0, //current_data_pointer- t_begin_of_data+1");
-			out_cc->println(" 0); //(t_end_of_data) - (t_begin_of_data)");
-			out_cc->println("}");
-			out_cc->dec_indent();
-			SetBoundaryChecked();	// to evict double checking
-		}
-		//otherwise, check the until condition
-		else{
+		//only if the number of array elements is unknown, set the until check
+		if(!env->Evaluated(arraylength_var())){
 			out_cc->println("// Check &until(%s)", until_expr->orig());
 			out_cc->println("if ( %s )",
 				until_expr->EvalExpr(out_cc, &check_env));


### PR DESCRIPTION
Hi,

I'm using binpac to implement a complex parser and embed its functionality with the Bro NIDS. 

During the development and testing of the software I realized that in some particular cases binpac does not throw an out-of-bound exception while parsing an array with invalid size (it should throw the exception). Furthermore, if the array is the last element of the current packet then nothing else will raise an exception. By consequence, binpac will go to the message's linked routine to generate the Bro event and call a routine to convert the binpac vector to a compatible Bro policy script type. My routine will then slide on the array to extract its elements. If, at this point, I use the field used in the formal specifications to specify the length of the array I will get the wrong value and the code will get a segmentation fault because it will try to read more elements than how many are actually in the vector.

The present patch is pretty rough but with it the problem is solved because binpac raises the exception as it's supposed to do. I didn't observed any malfunctioning of binpac with my mods

note: the added throw statement does not specify the violated bounds because I was not able to always put the right variables there, but the comments should help. For you that shouldn't be hard to adjust

I hope you understand the problem I'm pointing at but let me know if I can clarify and/or help.


Signed-off-by: Tomas Bortoli <tomasbortoli@gmail.com>