### PR TITLE
Use standard cmake installation dir variables.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@ include(cmake/CommonCMakeConfig.cmake)
 
 file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/VERSION" BINPAC_VERSION LIMIT_COUNT 1)
 
+# Set default install paths
+include(GNUInstallDirs)
+
 ########################################################################
 ## Dependency Configuration
 

--- a/configure
+++ b/configure
@@ -21,6 +21,7 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
 
   Installation Directories:
     --prefix=PREFIX        installation directory [/usr/local]
+    --libdir=LIBDIR        installation directory for libraries (lib or lib64 or lib/<multiarch-tuple> on Debian)
 
   Optional Features:
     --enable-debug         compile in debugging mode
@@ -74,6 +75,9 @@ while [ $# -ne 0 ]; do
             ;;
         --prefix=*)
             append_cache_entry CMAKE_INSTALL_PREFIX PATH   $optarg
+            ;;
+        --libdir=*)
+            append_cache_entry CMAKE_INSTALL_LIBDIR PATH   $optarg
             ;;
         --enable-debug)
             append_cache_entry ENABLE_DEBUG         BOOL   true

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -29,13 +29,13 @@ add_library(binpac_lib STATIC ${binpac_lib_SRCS})
 
 set_target_properties(binpac_lib PROPERTIES OUTPUT_NAME binpac)
 
-install(TARGETS binpac_lib DESTINATION lib)
+install(TARGETS binpac_lib DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 if ( BRO_ROOT_DIR )
     # Installed in binpac subdir just for organization purposes.
-    install(FILES ${binpac_headers} DESTINATION include/binpac)
+    install(FILES ${binpac_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/binpac)
 else ()
-    install(FILES ${binpac_headers} DESTINATION include)
+    install(FILES ${binpac_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 endif ()
 
 # This is set to assist superprojects that want to build BinPac


### PR DESCRIPTION
Not sure if you guys take PRs via GitHub. I'd like the change the install for the library archive to use the standard CMAKE vars, which factor in multi-lib architectures (i.e. install libbinpac.a to /usr/lib64 in x86_64 dirs).

For the include headers, I substituted the standard var there too, even though it's not multi-lib specific.