### PR TITLE
pac_scan: Exit with failure for include errors

### DIFF
--- a/src/pac_scan.ll
+++ b/src/pac_scan.ll
@@ -312,8 +312,7 @@ void switch_to_file(const char *filename)
 		{
 		fprintf(stderr, "%s:%d: error: cannot include file \"%s\"\n",
 			input_filename.c_str(), line_number,filename);
-		--include_stack_ptr;
-		return;
+		exit( 1 );
 		}
 
 	yyin = fp;
@@ -345,7 +344,7 @@ void include_file(const char *filename)
                     input_filename.c_str(), line_number, filename,
                     strerror(errno));
             delete [] tmp;
-            return;
+            exit( 1 );
             }
 
         delete [] tmp;


### PR DESCRIPTION
Elsewhere (zeek/zeek#2482), it was observed that when binpac encounters include failures, it still exits with 0 indicating success. Subsequent compilation of the produced .h and .cc files likely fails.

Exit with 1 on include errors to make pin pointing issues easier by having make/ninja stop earlier.