### PR TITLE
address linter warnings about use of sprintf()

### DIFF
--- a/src/pac_parse.yy
+++ b/src/pac_parse.yy
@@ -1068,17 +1068,17 @@ const ID* current_decl_id = 0;
 
 int yyerror(const char msg[])
 	{
-	char* msgbuf =
-		new char[strlen(msg) + yyleng + 64];
+	auto n = strlen(msg) + yyleng + 64;
+	char* msgbuf = new char[n];
 
 	if ( ! yychar || ! yytext || yytext[0] == '\0' )
-		sprintf(msgbuf, "%s, at end of file", msg);
+		snprintf(msgbuf, n, "%s, at end of file", msg);
 
 	else if ( yytext[0] == '\n' )
-		sprintf(msgbuf, "%s, on previous line", msg);
+		snprintf(msgbuf, n, "%s, on previous line", msg);
 
 	else
-		sprintf(msgbuf, "%s, at or near \"%s\"", msg, yytext);
+		snprintf(msgbuf, n, "%s, at or near \"%s\"", msg, yytext);
 
 	/*
 	extern int column;


### PR DESCRIPTION
A recent `clang` update started generating warnings for any use of `sprintf()`.  This PR fixes those appearing in BinPAC, which are distracting when doing Zeek builds.