### PR TITLE
Use relative/include filenames in Object

### DIFF
--- a/src/pac_common.h
+++ b/src/pac_common.h
@@ -14,6 +14,7 @@ extern bool FLAGS_pac_debug;
 extern bool FLAGS_quiet;
 extern vector<string> FLAGS_include_directories;
 extern string input_filename;
+extern string orig_filename;
 extern int line_number;
 
 // Definition of class Object, which is the base class for all objects
@@ -25,7 +26,7 @@ class Object
 public:
 	Object()
 		{
-		filename = input_filename;
+		filename = orig_filename;
 		line_num = line_number;
 		location = strfmt("%s:%d", filename.c_str(), line_number);
 		}

--- a/src/pac_main.cc
+++ b/src/pac_main.cc
@@ -15,7 +15,8 @@
 extern int yydebug;
 extern int yyparse();
 extern void switch_to_file(FILE* fp_input);
-string input_filename;
+string input_filename; // tracking current absolute filename of input file
+string orig_filename; // tracking filename as used on command line or #include
 
 bool FLAGS_pac_debug = false;
 bool FLAGS_quiet = false;
@@ -106,6 +107,7 @@ int compile(const char* filename)
 		return -1;
 		}
 	input_filename = filename;
+	orig_filename = filename;
 
 	string basename;
 
@@ -185,6 +187,7 @@ int compile(const char* filename)
 	header_output = 0;
 	source_output = 0;
 	input_filename = "";
+	orig_filename = "";
 	fclose(fp_input);
 
 	return ret;

--- a/src/pac_scan.ll
+++ b/src/pac_scan.ll
@@ -308,6 +308,7 @@ const int MAX_INCLUDE_DEPTH = 100;
 struct IncludeState {
 	YY_BUFFER_STATE yystate;
 	string input_filename;
+	string orig_filename;
 	int line_number;
 };
 
@@ -319,7 +320,7 @@ void switch_to_file(FILE *fp)
 	yy_switch_to_buffer(yy_create_buffer(fp, YY_BUF_SIZE));
 	}
 
-void switch_to_file(const char *filename)
+void switch_to_file(const char *filename, const char *orig_filename_arg)
 	{
 	if ( include_stack_ptr >= MAX_INCLUDE_DEPTH )
 		{
@@ -328,7 +329,7 @@ void switch_to_file(const char *filename)
 		}
 
 	IncludeState state =
-		{ YY_CURRENT_BUFFER, input_filename, line_number };
+		{ YY_CURRENT_BUFFER, input_filename, orig_filename, line_number };
 	include_stack[include_stack_ptr++] = state;
 
 	FILE *fp = fopen(filename, "r");
@@ -342,6 +343,7 @@ void switch_to_file(const char *filename)
 
 	yyin = fp;
 	input_filename = string(filename);
+	orig_filename = string(orig_filename_arg);
 	line_number = 1;
 	switch_to_file(yyin);
 	if ( ! FLAGS_quiet )
@@ -384,7 +386,7 @@ void include_file(const char *filename)
 			full_filename = filename;
 		}
 
-	switch_to_file(full_filename.c_str());
+	switch_to_file(full_filename.c_str(), filename);
 	}
 
 int yywrap()
@@ -397,6 +399,7 @@ int yywrap()
 	IncludeState state = include_stack[include_stack_ptr];
 	yy_switch_to_buffer(state.yystate);
 	input_filename = state.input_filename;
+	orig_filename = state.orig_filename;
 	line_number = state.line_number;
 	return 0;
 	}


### PR DESCRIPTION
This relates to zeek/zeek#2659 where the actual violation message that's created from the binpac exception contains absolute paths to the .pac files used during the built.

With this change, we instead use names as provided on the command-line or the values used in `#include` directives. These are shorter and do not include build-dependent information.