### PR TITLE
Some modernization work of binpac's codebase

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,251 @@
+##################################################################################
+# Please note:                                                                   #
+#                                                                                #
+# After updating this file, please also update CI column of the support matrix   #
+# at https://github.com/zeek/zeek/wiki/Zeek-Operating-System-Support-Matrix      #
+##################################################################################
+
+cpus: &CPUS 4
+memory: &MEMORY 12GB
+
+config: &CONFIG --enable-static --prefix=$CIRRUS_WORKING_DIR/install
+
+resources_template: &RESOURCES_TEMPLATE
+  cpu: *CPUS
+  memory: *MEMORY
+  # For greediness, see https://medium.com/cirruslabs/introducing-greedy-container-instances-29aad06dc2b4
+  greedy: true
+
+macos_environment: &MACOS_ENVIRONMENT
+  # https://medium.com/cirruslabs/new-macos-task-execution-architecture-for-cirrus-ci-604250627c94
+  # suggests we can go faster here:
+  env:
+    ZEEK_CI_CPUS: 12
+    # No permission to write to default location of /zeek
+    CIRRUS_WORKING_DIR: /tmp/binpac
+
+freebsd_resources_template: &FREEBSD_RESOURCES_TEMPLATE
+  cpu: 8
+  # Not allowed to request less than 8GB for an 8 CPU FreeBSD VM.
+  memory: 8GB
+  # For greediness, see https://medium.com/cirruslabs/introducing-greedy-container-instances-29aad06dc2b4
+  greedy: true
+
+freebsd_environment: &FREEBSD_ENVIRONMENT
+  env:
+    ZEEK_CI_CPUS: 8
+
+sanitizers_resource_template: &SANITIZERS_RESOURCE_TEMPLATE
+  cpu: 4
+  # Sanitizers uses a lot more memory than a typical config.
+  memory: 12GB
+  # For greediness, see https://medium.com/cirruslabs/introducing-greedy-container-instances-29aad06dc2b4
+  greedy: true
+
+branch_whitelist: &BRANCH_WHITELIST
+  # Rules for skipping builds:
+  # - Don't do darwin builds on zeek-security repo because they use up a ton of compute credits.
+  # - Always build PRs, but not if they come from dependabot
+  # - Always build master and release/* builds from the main repo
+  only_if: >
+    ( $CIRRUS_PR != '' && $CIRRUS_BRANCH !=~ 'dependabot/.*' ) ||
+    ( $CIRRUS_REPO_NAME == 'binpac' &&
+      (
+      $CIRRUS_BRANCH == 'master' ||
+      $CIRRUS_BRANCH =~ 'release/.*'
+      )
+    )
+
+skip_task_on_pr: &SKIP_TASK_ON_PR
+  # Skip this task on PRs if it does not have the fullci label,
+  # it continues to run for direct pushes to master/release.
+  skip: >
+    ($CIRRUS_PR != '' && $CIRRUS_PR_LABELS !=~ '.*fullci.*')
+
+ci_template: &CI_TEMPLATE
+  << : *BRANCH_WHITELIST
+
+  # Default timeout is 60 minutes, Cirrus hard limit is 120 minutes for free
+  # tasks, so may as well ask for full time.
+  timeout_in: 120m
+
+  sync_submodules_script: git submodule update --recursive --init
+
+  build_script: ./ci/build.sh
+
+env:
+  CIRRUS_WORKING_DIR: /binpac
+  ZEEK_CI_CPUS: *CPUS
+  ZEEK_CI_CONFIGURE_FLAGS: *CONFIG
+
+# Linux EOL timelines: https://linuxlifecycle.com/
+# Fedora (~13 months): https://fedoraproject.org/wiki/Fedora_Release_Life_Cycle
+
+fedora37_task:
+  container:
+    # Fedora 37 EOL: Around Dec 2024
+    dockerfile: ci/fedora-37/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+
+fedora36_task:
+  container:
+    # Fedora 36 EOL: Around May 2023
+    dockerfile: ci/fedora-36/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+  << : *SKIP_TASK_ON_PR
+
+centosstream9_task:
+  container:
+    # Stream 9 EOL: Around Dec 2027
+    dockerfile: ci/centos-stream-9/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+
+centosstream8_task:
+  container:
+    # Stream 8 EOL: May 31, 2024
+    dockerfile: ci/centos-stream-8/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+  << : *SKIP_TASK_ON_PR
+
+centos7_task:
+  container:
+    # CentOS 7 EOL: June 30, 2024
+    dockerfile: ci/centos-7/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+  << : *SKIP_TASK_ON_PR
+
+debian11_task:
+  container:
+    # Debian 11 EOL: June 2026
+    dockerfile: ci/debian-11/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+
+debian11_static_task:
+  container:
+    # Just use a recent/common distro to run a static compile test.
+    # Debian 11 EOL: June 2026
+    dockerfile: ci/debian-11/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+  << : *SKIP_TASK_ON_PR
+
+debian10_task:
+  container:
+    # Debian 10 EOL: June 2024
+    dockerfile: ci/debian-10/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+  << : *SKIP_TASK_ON_PR
+
+opensuse_leap_15_4_task:
+  container:
+    # Opensuse Leap 15.4 EOL: ~Nov 2023
+    dockerfile: ci/opensuse-leap-15.4/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+
+opensuse_tumbleweed_task:
+  container:
+    # Opensuse Tumbleweed has no EOL
+    dockerfile: ci/opensuse-tumbleweed/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+  << : *SKIP_TASK_ON_PR
+
+ubuntu2210_task:
+  container:
+    # Ubuntu 22.10 EOL: July 2023
+    dockerfile: ci/ubuntu-22.10/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+  << : *SKIP_TASK_ON_PR
+
+ubuntu22_task:
+  container:
+    # Ubuntu 22.04 EOL: April 2027
+    dockerfile: ci/ubuntu-22.04/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+
+ubuntu20_task:
+  container:
+    # Ubuntu 20.04 EOL: April 2025
+    dockerfile: ci/ubuntu-20.04/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+  << : *SKIP_TASK_ON_PR
+
+ubuntu18_task:
+  container:
+    # Ubuntu 18.04 EOL: April 2023
+    dockerfile: ci/ubuntu-18.04/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+  << : *SKIP_TASK_ON_PR
+
+alpine_task:
+  container:
+    # Alpine releases typically happen every 6 months w/ support for 2 years.
+    # The Dockerfile simply tracks latest Alpine release and shouldn't
+    # generally need updating based on particular Alpine release timelines.
+    dockerfile: ci/alpine/Dockerfile
+    << : *RESOURCES_TEMPLATE
+  << : *CI_TEMPLATE
+
+# Apple doesn't publish official long-term support timelines.
+# We aim to support both the current and previous macOS release.
+macos_ventura_task:
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-ventura-base:latest
+  prepare_script: ./ci/macos/prepare.sh
+  << : *CI_TEMPLATE
+  << : *MACOS_ENVIRONMENT
+
+macos_monterey_task:
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-monterey-base:latest
+  prepare_script: ./ci/macos/prepare.sh
+  << : *CI_TEMPLATE
+  << : *MACOS_ENVIRONMENT
+  << : *SKIP_TASK_ON_PR
+
+# FreeBSD EOL timelines: https://www.freebsd.org/security/#sup
+freebsd14_task:
+  freebsd_instance:
+    # We don't support FreeBSD 14 yet, this is a purely informative task
+    image_family: freebsd-14-0-snap
+    allow_failures: true
+    skip_notification: true
+    << : *FREEBSD_RESOURCES_TEMPLATE
+
+  prepare_script: ./ci/freebsd/prepare.sh
+  << : *CI_TEMPLATE
+  << : *FREEBSD_ENVIRONMENT
+
+freebsd13_task:
+  freebsd_instance:
+    # FreeBSD 13 EOL: January 31, 2026
+    image_family: freebsd-13-1
+    << : *FREEBSD_RESOURCES_TEMPLATE
+
+  prepare_script: ./ci/freebsd/prepare.sh
+  << : *CI_TEMPLATE
+  << : *SKIP_TASK_ON_PR
+  << : *FREEBSD_ENVIRONMENT
+
+freebsd12_task:
+  freebsd_instance:
+    # FreeBSD 12 EOL: June 30, 2024
+    image_family: freebsd-12-3
+    << : *FREEBSD_RESOURCES_TEMPLATE
+
+  prepare_script: ./ci/freebsd/prepare.sh
+  << : *CI_TEMPLATE
+  << : *SKIP_TASK_ON_PR
+  << : *FREEBSD_ENVIRONMENT

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,6 @@
+Checks: '-*,
+         bugprone-*,
+	 modernize-use-nullptr,
+	 -bugprone-easily-swappable-parameters,
+         clang-analyzer-*,
+         performance-*'

--- a/.github/workflows/ci-notification.yml
+++ b/.github/workflows/ci-notification.yml
@@ -1,0 +1,26 @@
+name: CI Email Notification
+on:
+  check_suite:
+    types: [completed]
+jobs:
+  notify:
+    if: github.repository == 'zeek/binpac'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Show the event
+        run: cat "$GITHUB_EVENT_PATH" || true
+
+      - name: Send CI Email Notification
+        uses: zeek/ci-email-action@master
+        env:
+          CI_APP_NAME: "Cirrus CI"
+          BRANCH_REGEX: "master|release/.*"
+          SKIP_CONCLUSIONS: 'cancelled,neutral,skipped'
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASS: ${{ secrets.SMTP_PASS }}
+          MAIL_FROM: ${{ secrets.MAIL_FROM }}
+          MAIL_TO: ${{ secrets.MAIL_TO }}
+          MAIL_REPLY_TO: ${{ secrets.MAIL_REPLY_TO }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README
+++ b/README
@@ -7,12 +7,10 @@
 BinPAC
 ======
 
-.. rst-class:: opening
-
-    BinPAC is a high level language for describing protocol parsers and
-    generates C++ code.  It is currently maintained and distributed with the
-    Zeek Network Security Monitor distribution, however, the generated parsers
-    may be used with other programs besides Zeek.
+BinPAC is a high level language for describing protocol parsers and
+generates C++ code.  It is currently maintained and distributed with the
+Zeek Network Security Monitor distribution, however, the generated parsers
+may be used with other programs besides Zeek.
 
 .. contents::
 
@@ -96,7 +94,7 @@ Defining an analyzer
 --------------------
 
 There are two components to an analyzer definition: the top level context
-and the connection definition. 
+and the connection definition.
 
 
 Context Definition
@@ -164,7 +162,7 @@ PAC grammar::
 
  type myType = record {
     data:uint8;
- };  
+ };
 
 PAC header::
 
@@ -199,7 +197,7 @@ Examples:
 
 .. code::
 
- type foo = record { x: number; }; 
+ type foo = record { x: number; };
 
 is equivalent to:
 
@@ -254,7 +252,7 @@ the following example.
  };
 
 Note that only one field is allowed after a given label. If multiple fields
-are to be specified, they should be packed in another "record" type first. 
+are to be specified, they should be packed in another "record" type first.
 The other usages of `case`_ are described later.
 
 array
@@ -266,10 +264,10 @@ Or an array size can be specified to control the number of
 match. &until can be also conditionally end parsing:
 
 .. code::
- 
+
  # This will match for 10 element only
  type HTTP_Headers = HTTP_Header [10];
- 
+
  # This will match until the condition is met
  type HTTP_Headers = HTTP_Header [] &until(/*Some condition*/);
 
@@ -504,7 +502,7 @@ condition for array parsing.
 &requires
 .........
 
-Process data dependencies before evaluating field. 
+Process data dependencies before evaluating field.
 
 Example: typically, derivative field is evaluated after primary field.
 However "&requires" is used to force evaluate of length before msg_body.
@@ -673,7 +671,7 @@ the compiler will assume the "int" type.
 
 PAC grammar::
 
- let myValue:uint8=10; 
+ let myValue:uint8=10;
 
 PAC source::
 
@@ -852,7 +850,7 @@ it would only mark the start and end pointer instead of copying.
 
 - void **AppendToBuffer**\(const_byteptr data, int len);
 
-  - Reallocate buffer\_ to add new data then copy data 
+  - Reallocate buffer\_ to add new data then copy data
 
 - void **ExpandBuffer**\(int length);
 
@@ -962,7 +960,7 @@ binpac_pcre.h
         }
         return 1;
     }
-    
+
     int MatchPrefix (const char* s, int n){
         const char *err=NULL;
         assert(pcre_);
@@ -971,7 +969,7 @@ binpac_pcre.h
         int ret = pcre_exec(pcre_,
                                     pextra_,  // pcre_extra
                                     //NULL,  // pcre_extra
-                                    s, n,  
+                                    s, n,
                                     0,     // offset
                                     0,     // options
                                     offsets,
@@ -1015,7 +1013,7 @@ Q & A
 
   And the code of flow_buffer_t provides the functionality of buffering up to
   one line. That's why &oneline is only active when "flow" is used and the
-  type requires buffering. 
+  type requires buffering.
 
   In certain cases we would want to use &oneline even if the type does
   not require buffering, binpac currently does not provide such functionality.
@@ -1062,7 +1060,7 @@ Q & A
 
     // Parse "name"
     int t_name_string_length;
-    t_name_string_length = 
+    t_name_string_length =
         HTTP_HEADER_NAME_re_011.MatchPrefix(
             t_begin_of_data,
             t_end_of_data - t_begin_of_data);
@@ -1144,4 +1142,3 @@ Things that compiler should flag out at code generation time
 * Give warning when &oneline, &length is used and flowunit is not.
 
 * Warning when more than one "connection" is defined
-

--- a/ci/README
+++ b/ci/README
@@ -1,0 +1,23 @@
+=========================================
+Continuous Integration Configuration Info
+=========================================
+
+The following pointers are aimed at maintainers to help describe a few points
+about the Cirrus CI setup that may not be obvious/intuitive.
+
+Email Notifications
+-------------------
+
+Cirrus CI doesn't feature any way to perform email notifications on failures,
+so that is instead handled by a separate GitHub Action:
+
+  https://github.com/zeek/ci-email-action
+
+The configuration of that GitHub Action is typical: it's the
+``.github/workflows/ci-notification.yml`` file, which sets SMTP/mail info
+via secrets stored in GitHub for the Zeek organization:
+
+  https://github.com/organizations/zeek/settings/secrets
+
+The particular values used for those are currently from the Zeek project's AWS
+Simple Email Service configuration.

--- a/ci/alpine/Dockerfile
+++ b/ci/alpine/Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine:latest
+
+# A version field to invalidate Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20230113
+
+RUN apk add --no-cache \
+  bash \
+  bison \
+  cmake \
+  flex-dev \
+  g++ \
+  git \
+  linux-headers \
+  make

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,0 +1,26 @@
+#! /usr/bin/env bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+. ${SCRIPT_DIR}/common.sh
+
+set -e
+set -x
+
+if [[ "${CIRRUS_OS}" == "darwin" ]]; then
+    # Starting with Monterey & Xcode 13.1 we need to help it find OpenSSL
+    if [ -d /usr/local/opt/openssl@1.1/lib/pkgconfig ]; then
+        export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/opt/openssl@1.1/lib/pkgconfig
+    fi
+fi
+
+if [[ "${ZEEK_CI_CREATE_ARTIFACT}" != "1" ]]; then
+    ./configure ${ZEEK_CI_CONFIGURE_FLAGS}
+    cd build
+    make -j ${ZEEK_CI_CPUS}
+else
+    ./configure ${ZEEK_CI_CONFIGURE_FLAGS} --prefix=${CIRRUS_WORKING_DIR}/install
+    cd build
+    make -j ${ZEEK_CI_CPUS} install
+    cd ..
+    tar -czf ${CIRRUS_WORKING_DIR}/build.tgz ${CIRRUS_WORKING_DIR}/install
+fi

--- a/ci/centos-7/Dockerfile
+++ b/ci/centos-7/Dockerfile
@@ -1,0 +1,46 @@
+FROM centos:7
+
+# A version field to invalidate Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
+# Disabled lookup of fastest mirror since the list seems to be outdated and no valid mirror can be detected.
+RUN sed -i 's/enabled=1/enabled=0/' /etc/yum/pluginconf.d/fastestmirror.conf
+
+# The version of git in the standard repos is 1.8 and CI needs 2.3+
+# for the use of GIT_SSH_COMMAND when cloning private repos.
+RUN yum -y install \
+    https://repo.ius.io/ius-release-el7.rpm \
+    https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
+  && yum -y install git236 \
+  && yum clean all && rm -rf /var/cache/yum
+
+RUN yum -y install \
+    epel-release \
+  && yum clean all && rm -rf /var/cache/yum
+
+RUN yum -y install \
+    centos-release-scl \
+  && yum clean all && rm -rf /var/cache/yum
+
+RUN yum -y install \
+    devtoolset-8 \
+  && yum clean all && rm -rf /var/cache/yum
+
+RUN yum -y install \
+    flex \
+    bison \
+    cmake3 \
+    curl \
+    make \
+  && yum clean all && rm -rf /var/cache/yum
+
+RUN ln -s /usr/bin/cmake3 /usr/bin/cmake
+
+RUN echo 'unset BASH_ENV PROMPT_COMMAND ENV' > /usr/bin/zeek-ci-env && \
+    echo 'source /opt/rh/devtoolset-8/enable' >> /usr/bin/zeek-ci-env && \
+    echo 'export PATH=${PATH}:${FLEX_DIR}/bin' >> /usr/bin/zeek-ci-env
+
+ENV BASH_ENV="/usr/bin/zeek-ci-env" \
+    ENV="/usr/bin/zeek-ci-env" \
+    PROMPT_COMMAND=". /usr/bin/zeek-ci-env"

--- a/ci/centos-stream-8/Dockerfile
+++ b/ci/centos-stream-8/Dockerfile
@@ -1,0 +1,18 @@
+FROM quay.io/centos/centos:stream8
+
+# A version field to invalidate Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
+RUN dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+RUN dnf config-manager --set-enabled powertools
+
+RUN dnf -y install \
+    bison \
+    cmake \
+    flex \
+    gcc \
+    gcc-c++ \
+    git \
+    make \
+  && dnf clean all && rm -rf /var/cache/dnf

--- a/ci/centos-stream-9/Dockerfile
+++ b/ci/centos-stream-9/Dockerfile
@@ -1,0 +1,29 @@
+FROM quay.io/centos/centos:stream9
+
+# A version field to invalidate Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
+# dnf config-manager isn't available at first, and
+# we need it to install the CRB repo below.
+RUN dnf -y install 'dnf-command(config-manager)'
+
+# What used to be powertools is now called "CRB".
+# We need it for some of the packages installed below.
+# https://docs.fedoraproject.org/en-US/epel/
+RUN dnf config-manager --set-enabled crb
+RUN dnf -y install \
+    https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm \
+    https://dl.fedoraproject.org/pub/epel/epel-next-release-latest-9.noarch.rpm
+
+# The --nobest flag is hopefully temporary. Without it we currently hit
+# package versioning conflicts around OpenSSL.
+RUN dnf -y --nobest install \
+    bison \
+    cmake \
+    flex \
+    gcc \
+    gcc-c++ \
+    git \
+    make \
+  && dnf clean all && rm -rf /var/cache/dnf

--- a/ci/common.sh
+++ b/ci/common.sh
@@ -1,0 +1,12 @@
+# Common material sourced by Bash CI scripts in this directory
+
+# On Cirrus, oversubscribe the CPUs when on Linux or FreeBSD. This uses Cirrus' "greedy" feature.
+if [[ "${CIRRUS_OS}" == linux || "${CIRRUS_OS}" == freebsd ]]; then
+    if [[ -n "${ZEEK_CI_CPUS}" ]]; then
+        ZEEK_CI_CPUS=$((2 * ${ZEEK_CI_CPUS}))
+    fi
+
+    if [[ -n "${ZEEK_CI_BTEST_JOBS}" ]]; then
+        ZEEK_CI_BTEST_JOBS=$((2 * ${ZEEK_CI_BTEST_JOBS}))
+    fi
+fi

--- a/ci/debian-10/Dockerfile
+++ b/ci/debian-10/Dockerfile
@@ -1,0 +1,28 @@
+FROM debian:10
+
+ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
+
+# A version field to invalidate Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
+ENV CMAKE_DIR "/opt/cmake"
+ENV CMAKE_VERSION "3.19.1"
+ENV PATH "${CMAKE_DIR}/bin:${PATH}"
+
+RUN apt-get update && apt-get -y install \
+    bison \
+    curl \
+    flex \
+    g++ \
+    gcc \
+    git \
+    gzip \
+    make \
+    tar \
+  && apt autoclean \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install a more recent version of CMake
+RUN mkdir -p "${CMAKE_DIR}" \
+  && curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" | tar xzf - -C "${CMAKE_DIR}" --strip-components 1

--- a/ci/debian-11/Dockerfile
+++ b/ci/debian-11/Dockerfile
@@ -1,0 +1,18 @@
+FROM debian:11
+
+ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
+
+# A version field to invalidate Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
+RUN apt-get update && apt-get -y install \
+    bison \
+    cmake \
+    flex \
+    g++ \
+    gcc \
+    git \
+    make \
+  && apt autoclean \
+  && rm -rf /var/lib/apt/lists/*

--- a/ci/fedora-36/Dockerfile
+++ b/ci/fedora-36/Dockerfile
@@ -1,0 +1,15 @@
+FROM fedora:36
+
+# A version field to invalidate Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220614
+
+RUN dnf -y install \
+    bison \
+    cmake \
+    flex \
+    gcc \
+    gcc-c++ \
+    git \
+    make \
+  && dnf clean all && rm -rf /var/cache/dnf

--- a/ci/fedora-37/Dockerfile
+++ b/ci/fedora-37/Dockerfile
@@ -1,0 +1,15 @@
+FROM fedora:37
+
+# A version field to invalidate Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20221127
+
+RUN dnf -y install \
+    bison \
+    cmake \
+    flex \
+    gcc \
+    gcc-c++ \
+    git \
+    make \
+  && dnf clean all && rm -rf /var/cache/dnf

--- a/ci/freebsd/prepare.sh
+++ b/ci/freebsd/prepare.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+echo "Preparing FreeBSD environment"
+sysctl hw.model hw.machine hw.ncpu
+set -e
+set -x
+
+env ASSUME_ALWAYS_YES=YES pkg bootstrap
+pkg install -y bash git cmake bison base64 flex
+pkg upgrade -y curl

--- a/ci/macos/prepare.sh
+++ b/ci/macos/prepare.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+echo "Preparing macOS environment"
+sysctl hw.model hw.machine hw.ncpu hw.physicalcpu hw.logicalcpu
+set -e
+set -x
+
+brew update
+brew upgrade cmake
+brew install bison flex

--- a/ci/opensuse-leap-15.4/Dockerfile
+++ b/ci/opensuse-leap-15.4/Dockerfile
@@ -1,0 +1,20 @@
+FROM opensuse/leap:15.4
+
+# A version field to invalidate Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220615
+
+RUN zypper addrepo https://download.opensuse.org/repositories/openSUSE:Leap:15.4:Update/standard/openSUSE:Leap:15.4:Update.repo \
+ && zypper refresh \
+ && zypper in -y \
+    bison \
+    cmake \
+    flex \
+    gcc10 \
+    gcc10-c++ \
+    git \
+    make \
+  && rm -rf /var/cache/zypp
+
+RUN update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-10 100
+RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-10 100

--- a/ci/opensuse-tumbleweed/Dockerfile
+++ b/ci/opensuse-tumbleweed/Dockerfile
@@ -1,0 +1,16 @@
+FROM opensuse/tumbleweed
+
+# A version field to invalidate Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20221027
+
+RUN zypper refresh \
+ && zypper in -y \
+    bison \
+    cmake \
+    flex \
+    gcc \
+    gcc-c++ \
+    git \
+    make \
+  && rm -rf /var/cache/zypp

--- a/ci/ubuntu-18.04/Dockerfile
+++ b/ci/ubuntu-18.04/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:18.04
+
+ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
+
+# A version field to invalidate Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
+ENV CMAKE_DIR "/opt/cmake"
+ENV CMAKE_VERSION "3.19.1"
+ENV PATH "${CMAKE_DIR}/bin:${PATH}"
+
+RUN apt-get update && apt-get -y install \
+    bison \
+    clang-10 \
+    curl \
+    flex \
+    git \
+    gzip \
+    make \
+    tar \
+  && apt-get autoclean \
+  && rm -rf /var/lib/apt/lists/*
+
+# Recent CMake.
+RUN mkdir -p "${CMAKE_DIR}" \
+  && curl -sSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz" | tar xzf - -C "${CMAKE_DIR}" --strip-components 1
+
+RUN update-alternatives --install /usr/bin/cc cc /usr/bin/clang-10 100
+RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-10 100

--- a/ci/ubuntu-20.04/Dockerfile
+++ b/ci/ubuntu-20.04/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
+
+# A version field to invalidate Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220519
+
+RUN apt-get update && apt-get -y install \
+    bison \
+    cmake \
+    curl \
+    flex \
+    g++ \
+    gcc \
+    git \
+    make \
+  && apt autoclean \
+  && rm -rf /var/lib/apt/lists/*

--- a/ci/ubuntu-22.04/Dockerfile
+++ b/ci/ubuntu-22.04/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
+
+# A version field to invalidate Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220614
+
+RUN apt-get update && apt-get -y install \
+    bison \
+    cmake \
+    flex \
+    g++ \
+    gcc \
+    git \
+    make \
+  && apt autoclean \
+  && rm -rf /var/lib/apt/lists/*

--- a/ci/ubuntu-22.10/Dockerfile
+++ b/ci/ubuntu-22.10/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:22.10
+
+ENV DEBIAN_FRONTEND="noninteractive" TZ="America/Los_Angeles"
+
+# A version field to invalide Cirrus's build cache when needed, as suggested in
+# https://github.com/cirruslabs/cirrus-ci-docs/issues/544#issuecomment-566066822
+ENV DOCKERFILE_VERSION 20220614
+
+RUN apt-get update && apt-get -y install \
+    bison \
+    cmake \
+    flex \
+    g++ \
+    gcc \
+    git \
+    make \
+  && apt autoclean \
+  && rm -rf /var/lib/apt/lists/*

--- a/lib/binpac_buffer.cc
+++ b/lib/binpac_buffer.cc
@@ -30,10 +30,10 @@ binpac::FlowBuffer::Policy binpac::FlowBuffer::policy = {
 FlowBuffer::FlowBuffer(LineBreakStyle linebreak_style)
 	{
 	buffer_length_ = 0;
-	buffer_ = 0;
+	buffer_ = nullptr;
 
-	orig_data_begin_ = 0;
-	orig_data_end_ = 0;
+	orig_data_begin_ = nullptr;
+	orig_data_end_ = nullptr;
 
 	linebreak_style_ = linebreak_style;
 	linebreak_style_default = linebreak_style;
@@ -209,7 +209,7 @@ void FlowBuffer::DiscardData()
 	mode_ = UNKNOWN_MODE;
 	message_complete_ = false;
 	have_pending_request_ = false;
-	orig_data_begin_ = orig_data_end_ = 0;
+	orig_data_begin_ = orig_data_end_ = nullptr;
 
 	buffer_n_ = 0;
 	frame_length_ = 0;
@@ -289,7 +289,7 @@ void FlowBuffer::NewGap(int length)
 			frame_length_ = 0;
 		}
 
-	orig_data_begin_ = orig_data_end_ = 0;
+	orig_data_begin_ = orig_data_end_ = nullptr;
 	MarkOrCopy();
 	}
 

--- a/lib/binpac_regex.cc
+++ b/lib/binpac_regex.cc
@@ -9,6 +9,6 @@ class RE_Matcher;
 namespace binpac
 	{
 
-std::vector<zeek::RE_Matcher*>* uncompiled_re_matchers = 0;
+std::vector<zeek::RE_Matcher*>* uncompiled_re_matchers = nullptr;
 
 	}

--- a/src/pac_action.cc
+++ b/src/pac_action.cc
@@ -10,7 +10,7 @@
 
 AnalyzerAction::AnalyzerAction(ID* action_id, When when, ActionParam* param, EmbeddedCode* code)
 	: AnalyzerElement(ACTION), action_id_(action_id), when_(when), param_(param), code_(code),
-	  analyzer_(0)
+	  analyzer_(nullptr)
 	{
 	}
 

--- a/src/pac_action.h
+++ b/src/pac_action.h
@@ -17,7 +17,7 @@ public:
 
 	AnalyzerAction(ID* action_id, When when, ActionParam* param, EmbeddedCode* code);
 
-	~AnalyzerAction();
+	~AnalyzerAction() override;
 
 	When when() const { return when_; }
 	ActionParam* param() const { return param_; }

--- a/src/pac_analyzer.cc
+++ b/src/pac_analyzer.cc
@@ -30,7 +30,7 @@ AnalyzerDecl::AnalyzerDecl(ID* id, DeclType decl_type, ParamList* params)
 
 	SetAnalyzerContext();
 
-	env_ = 0;
+	env_ = nullptr;
 	}
 
 AnalyzerDecl::~AnalyzerDecl()
@@ -205,7 +205,7 @@ void AnalyzerDecl::GenInitCode(Output* out_cc)
 	TypeDecl::GenInitCode(out_cc);
 	foreach (i, AnalyzerHelperList, constructor_helpers_)
 		{
-		(*i)->GenCode(0, out_cc, this);
+		(*i)->GenCode(nullptr, out_cc, this);
 		}
 	}
 
@@ -214,7 +214,7 @@ void AnalyzerDecl::GenCleanUpCode(Output* out_cc)
 	TypeDecl::GenCleanUpCode(out_cc);
 	foreach (i, AnalyzerHelperList, destructor_helpers_)
 		{
-		(*i)->GenCode(0, out_cc, this);
+		(*i)->GenCode(nullptr, out_cc, this);
 		}
 	}
 
@@ -277,7 +277,7 @@ AnalyzerHelper::~AnalyzerHelper()
 
 void AnalyzerHelper::GenCode(Output* out_h, Output* out_cc, AnalyzerDecl* decl)
 	{
-	Output* out = 0;
+	Output* out = nullptr;
 	switch ( helper_type_ )
 		{
 		case MEMBER_DECLS:
@@ -318,7 +318,7 @@ AnalyzerFlow::AnalyzerFlow(Direction dir, ID* type_id, ExprList* params)
 
 	flow_field_ = new FlowField(flow_id, flow_type);
 
-	flow_decl_ = 0;
+	flow_decl_ = nullptr;
 	}
 
 AnalyzerFlow::~AnalyzerFlow()

--- a/src/pac_analyzer.h
+++ b/src/pac_analyzer.h
@@ -21,16 +21,16 @@ class AnalyzerDecl : public TypeDecl
 	{
 public:
 	AnalyzerDecl(ID* id, DeclType decl_type, ParamList* params);
-	~AnalyzerDecl();
+	~AnalyzerDecl() override;
 
 	void AddElements(AnalyzerElementList* elemlist);
 
-	void Prepare();
-	void GenForwardDeclaration(Output* out_h);
+	void Prepare() override;
+	void GenForwardDeclaration(Output* out_h) override;
 	// void GenCode(Output *out_h, Output *out_cc);
 
-	void GenInitCode(Output* out_cc);
-	void GenCleanUpCode(Output* out_cc);
+	void GenInitCode(Output* out_cc) override;
+	void GenCleanUpCode(Output* out_cc) override;
 
 	string class_name() const;
 	// string cookie_name() const;
@@ -41,8 +41,8 @@ protected:
 
 	// Generate public/private declarations for member functions and
 	// variables
-	void GenPubDecls(Output* out_h, Output* out_cc);
-	void GenPrivDecls(Output* out_h, Output* out_cc);
+	void GenPubDecls(Output* out_h, Output* out_cc) override;
+	void GenPrivDecls(Output* out_h, Output* out_cc) override;
 
 	// Generate the NewData() function
 	virtual void GenProcessFunc(Output* out_h, Output* out_cc) = 0;
@@ -107,7 +107,7 @@ class AnalyzerState : public AnalyzerElement
 	{
 public:
 	AnalyzerState(StateVarList* statevars) : AnalyzerElement(STATE), statevars_(statevars) { }
-	~AnalyzerState();
+	~AnalyzerState() override;
 
 	StateVarList* statevars() const { return statevars_; }
 
@@ -130,7 +130,7 @@ public:
 		: AnalyzerElement(HELPER), helper_type_(helper_type), code_(code)
 		{
 		}
-	~AnalyzerHelper();
+	~AnalyzerHelper() override;
 
 	Type helper_type() const { return helper_type_; }
 
@@ -149,7 +149,7 @@ class FlowField : public Field
 	{
 public:
 	FlowField(ID* flow_id, ParameterizedType* flow_type);
-	void GenInitCode(Output* out, Env* env);
+	void GenInitCode(Output* out, Env* env) override;
 	};
 
 class AnalyzerFlow : public AnalyzerElement
@@ -161,7 +161,7 @@ public:
 		DOWN
 		};
 	AnalyzerFlow(Direction dir, ID* type_id, ExprList* params);
-	~AnalyzerFlow();
+	~AnalyzerFlow() override;
 
 	Direction dir() const { return dir_; }
 	FlowField* flow_field() const { return flow_field_; }

--- a/src/pac_array.cc
+++ b/src/pac_array.cc
@@ -37,13 +37,13 @@ ArrayType::ArrayType(Type* elemtype, Expr* length)
 
 void ArrayType::init()
 	{
-	arraylength_var_field_ = 0;
-	elem_it_var_field_ = 0;
-	elem_var_field_ = 0;
-	elem_dataptr_var_field_ = 0;
-	elem_input_var_field_ = 0;
+	arraylength_var_field_ = nullptr;
+	elem_it_var_field_ = nullptr;
+	elem_var_field_ = nullptr;
+	elem_dataptr_var_field_ = nullptr;
+	elem_input_var_field_ = nullptr;
 
-	elem_dataptr_until_expr_ = 0;
+	elem_dataptr_until_expr_ = nullptr;
 
 	end_of_array_loop_label_ = "@@@";
 
@@ -51,9 +51,9 @@ void ArrayType::init()
 
 	datatype_str_ = strfmt("%s *", vector_str_.c_str());
 
-	attr_generic_until_expr_ = 0;
-	attr_until_element_expr_ = 0;
-	attr_until_input_expr_ = 0;
+	attr_generic_until_expr_ = nullptr;
+	attr_until_element_expr_ = nullptr;
+	attr_until_input_expr_ = nullptr;
 	}
 
 ArrayType::~ArrayType()
@@ -71,7 +71,7 @@ Type* ArrayType::DoClone() const
 	{
 	Type* elemtype = elemtype_->Clone();
 	if ( ! elemtype )
-		return 0;
+		return nullptr;
 	return new ArrayType(elemtype, length_);
 	}
 
@@ -100,27 +100,27 @@ string ArrayType::EvalElement(const string& array, const string& index) const
 
 const ID* ArrayType::arraylength_var() const
 	{
-	return arraylength_var_field_ ? arraylength_var_field_->id() : 0;
+	return arraylength_var_field_ ? arraylength_var_field_->id() : nullptr;
 	}
 
 const ID* ArrayType::elem_it_var() const
 	{
-	return elem_it_var_field_ ? elem_it_var_field_->id() : 0;
+	return elem_it_var_field_ ? elem_it_var_field_->id() : nullptr;
 	}
 
 const ID* ArrayType::elem_var() const
 	{
-	return elem_var_field_ ? elem_var_field_->id() : 0;
+	return elem_var_field_ ? elem_var_field_->id() : nullptr;
 	}
 
 const ID* ArrayType::elem_dataptr_var() const
 	{
-	return elem_dataptr_var_field_ ? elem_dataptr_var_field_->id() : 0;
+	return elem_dataptr_var_field_ ? elem_dataptr_var_field_->id() : nullptr;
 	}
 
 const ID* ArrayType::elem_input_var() const
 	{
-	return elem_input_var_field_ ? elem_input_var_field_->id() : 0;
+	return elem_input_var_field_ ? elem_input_var_field_->id() : nullptr;
 	}
 
 void ArrayType::ProcessAttr(Attr* a)
@@ -499,7 +499,7 @@ void ArrayType::DoGenParseCode(Output* out_cc, Env* env, const DataPtr& data, in
 
 	ASSERT(elem_it_var());
 
-	DataPtr elem_data(env, 0, 0);
+	DataPtr elem_data(env, nullptr, 0);
 
 	if ( elem_dataptr_var() )
 		{
@@ -554,7 +554,7 @@ void ArrayType::DoGenParseCode(Output* out_cc, Env* env, const DataPtr& data, in
 	if ( elem_dataptr_var() )
 		{
 		out_cc->println("%s += %s;", env->LValue(elem_dataptr_var()),
-		                elemtype_->DataSize(0, env, elem_data).c_str());
+		                elemtype_->DataSize(nullptr, env, elem_data).c_str());
 		out_cc->println("BINPAC_ASSERT(%s <= %s);", env->RValue(elem_dataptr_var()),
 		                env->RValue(end_of_data));
 		}

--- a/src/pac_array.cc
+++ b/src/pac_array.cc
@@ -383,11 +383,10 @@ void ArrayType::GenCleanUpCode(Output* out_cc, Env* env)
 		out_cc->inc_indent();
 		out_cc->println("{");
 
-		out_cc->println("for ( int i = 0; i < (int) %s->size(); ++i )", env->RValue(value_var()));
+		out_cc->println("for ( auto* %s : *%s )", env->LValue(elem_var()),
+		                env->RValue(value_var()));
 		out_cc->inc_indent();
 		out_cc->println("{");
-		out_cc->println("%s %s = (*%s)[i];", elemtype_->DataTypeStr().c_str(),
-		                env->LValue(elem_var()), lvalue());
 		elemtype_->GenCleanUpCode(out_cc, env);
 		out_cc->println("}");
 		out_cc->dec_indent();

--- a/src/pac_array.cc
+++ b/src/pac_array.cc
@@ -356,7 +356,7 @@ void ArrayType::GenInitCode(Output* out_cc, Env* env)
 	{
 	// Do not initiate the array here
 	// out_cc->println("%s = new %s;", lvalue(), vector_str_.c_str());
-	out_cc->println("%s = 0;", lvalue());
+	out_cc->println("%s = nullptr;", lvalue());
 
 	Type::GenInitCode(out_cc, env);
 	if ( incremental_parsing() )
@@ -563,7 +563,7 @@ void ArrayType::DoGenParseCode(Output* out_cc, Env* env, const DataPtr& data, in
 		GenUntilCheck(out_cc, env, attr_until_element_expr_, false);
 
 	if ( elemtype_->IsPointerType() )
-		out_cc->println("%s = 0;", env->LValue(elem_var()));
+		out_cc->println("%s = nullptr;", env->LValue(elem_var()));
 
 	out_cc->println("}");
 	out_cc->dec_indent();
@@ -621,7 +621,7 @@ void ArrayType::GenUntilCheck(Output* out_cc, Env* env, Expr* until_expr, bool d
 		if ( delete_elem )
 			elemtype_->GenCleanUpCode(out_cc, env);
 		else
-			out_cc->println("%s = 0;", env->LValue(elem_var()));
+			out_cc->println("%s = nullptr;", env->LValue(elem_var()));
 		}
 
 	out_cc->println("goto %s;", end_of_array_loop_label_.c_str());

--- a/src/pac_array.cc
+++ b/src/pac_array.cc
@@ -252,7 +252,9 @@ void ArrayType::GenArrayLength(Output* out_cc, Env* env, const DataPtr& data)
 	if ( ! incremental_parsing() )
 		{
 		arraylength_var_field_->GenTempDecls(out_cc, env);
-		arraylength_var_field_->GenInitCode(out_cc, env);
+		// This is about to get initialized below, don't initialize it twice.
+		if ( ! length_ && ! attr_restofdata_ )
+			arraylength_var_field_->GenInitCode(out_cc, env);
 		}
 
 	if ( length_ )

--- a/src/pac_array.h
+++ b/src/pac_array.h
@@ -10,48 +10,48 @@ class ArrayType : public Type
 	{
 public:
 	ArrayType(Type* arg_elemtype, Expr* arg_length = nullptr);
-	~ArrayType();
+	~ArrayType() override;
 
-	bool DefineValueVar() const;
-	string DataTypeStr() const;
-	string DefaultValue() const { return "0"; }
-	Type* ElementDataType() const;
+	bool DefineValueVar() const override;
+	string DataTypeStr() const override;
+	string DefaultValue() const override { return "0"; }
+	Type* ElementDataType() const override;
 
-	string EvalElement(const string& array, const string& index) const;
+	string EvalElement(const string& array, const string& index) const override;
 
-	void ProcessAttr(Attr* a);
+	void ProcessAttr(Attr* a) override;
 
-	void Prepare(Env* env, int flags);
+	void Prepare(Env* env, int flags) override;
 
-	void GenPubDecls(Output* out, Env* env);
-	void GenPrivDecls(Output* out, Env* env);
+	void GenPubDecls(Output* out, Env* env) override;
+	void GenPrivDecls(Output* out, Env* env) override;
 
-	void GenInitCode(Output* out, Env* env);
-	void GenCleanUpCode(Output* out, Env* env);
+	void GenInitCode(Output* out, Env* env) override;
+	void GenCleanUpCode(Output* out, Env* env) override;
 
-	int StaticSize(Env* env) const;
+	int StaticSize(Env* env) const override;
 
-	void SetBoundaryChecked();
+	void SetBoundaryChecked() override;
 	void GenUntilInputCheck(Output* out_cc, Env* env);
 
-	bool IsPointerType() const { return true; }
+	bool IsPointerType() const override { return true; }
 
 protected:
 	void init();
 
-	void DoGenParseCode(Output* out, Env* env, const DataPtr& data, int flags);
-	void GenDynamicSize(Output* out, Env* env, const DataPtr& data);
+	void DoGenParseCode(Output* out, Env* env, const DataPtr& data, int flags) override;
+	void GenDynamicSize(Output* out, Env* env, const DataPtr& data) override;
 	void GenArrayLength(Output* out_cc, Env* env, const DataPtr& data);
 	string GenArrayInit(Output* out_cc, Env* env, bool known_array_length);
 	void GenElementAssignment(Output* out_cc, Env* env, string const& array_str, bool use_vector);
 	void GenUntilCheck(Output* out_cc, Env* env, Expr* until_condition, bool delete_elem);
 
-	bool ByteOrderSensitive() const { return elemtype_->RequiresByteOrder(); }
-	bool RequiresAnalyzerContext();
+	bool ByteOrderSensitive() const override { return elemtype_->RequiresByteOrder(); }
+	bool RequiresAnalyzerContext() override;
 
-	Type* DoClone() const;
+	Type* DoClone() const override;
 
-	void DoMarkIncrementalInput();
+	void DoMarkIncrementalInput() override;
 
 	const ID* arraylength_var() const;
 	const ID* elem_it_var() const;
@@ -60,7 +60,7 @@ protected:
 	const ID* elem_input_var() const;
 
 protected:
-	bool DoTraverse(DataDepVisitor* visitor);
+	bool DoTraverse(DataDepVisitor* visitor) override;
 
 private:
 	Type* elemtype_;

--- a/src/pac_array.h
+++ b/src/pac_array.h
@@ -9,7 +9,7 @@
 class ArrayType : public Type
 	{
 public:
-	ArrayType(Type* arg_elemtype, Expr* arg_length = 0);
+	ArrayType(Type* arg_elemtype, Expr* arg_length = nullptr);
 	~ArrayType();
 
 	bool DefineValueVar() const;

--- a/src/pac_attr.cc
+++ b/src/pac_attr.cc
@@ -16,8 +16,8 @@ bool Attr::RequiresAnalyzerContext() const
 
 void Attr::init()
 	{
-	expr_ = 0;
-	seqend_ = 0;
+	expr_ = nullptr;
+	seqend_ = nullptr;
 	delete_expr_ = false;
 	}
 

--- a/src/pac_attr.h
+++ b/src/pac_attr.h
@@ -33,7 +33,7 @@ public:
 	Attr(AttrType type, ExprList* exprlist);
 	Attr(AttrType type, SeqEnd* seqend);
 
-	virtual ~Attr();
+	~Attr() override;
 
 	AttrType type() const { return type_; }
 	Expr* expr() const { return expr_; }
@@ -42,7 +42,7 @@ public:
 	bool RequiresAnalyzerContext() const;
 
 protected:
-	bool DoTraverse(DataDepVisitor* visitor);
+	bool DoTraverse(DataDepVisitor* visitor) override;
 
 protected:
 	void init();

--- a/src/pac_btype.cc
+++ b/src/pac_btype.cc
@@ -25,7 +25,7 @@ static const char* basic_pactype_name[] = {
 #define TYPE_DEF(name, pactype, ctype, size) pactype,
 #include "pac_type.def"
 #undef TYPE_DEF
-	0,
+	nullptr,
 };
 
 void BuiltInType::static_init()
@@ -49,7 +49,7 @@ static const char* basic_ctype_name[] = {
 #define TYPE_DEF(name, pactype, ctype, size) ctype,
 #include "pac_type.def"
 #undef TYPE_DEF
-	0,
+	nullptr,
 };
 
 bool BuiltInType::DefineValueVar() const

--- a/src/pac_btype.h
+++ b/src/pac_btype.h
@@ -22,26 +22,26 @@ public:
 
 	BITType bit_type() const { return bit_type_; }
 
-	bool IsNumericType() const;
+	bool IsNumericType() const override;
 
-	bool DefineValueVar() const;
-	string DataTypeStr() const;
-	string DefaultValue() const { return "0"; }
+	bool DefineValueVar() const override;
+	string DataTypeStr() const override;
+	string DefaultValue() const override { return "0"; }
 
-	int StaticSize(Env* env) const;
+	int StaticSize(Env* env) const override;
 
-	bool IsPointerType() const { return false; }
+	bool IsPointerType() const override { return false; }
 
-	bool ByteOrderSensitive() const { return StaticSize(0) >= 2; }
+	bool ByteOrderSensitive() const override { return StaticSize(0) >= 2; }
 
-	void GenInitCode(Output* out_cc, Env* env);
+	void GenInitCode(Output* out_cc, Env* env) override;
 
-	void DoMarkIncrementalInput();
+	void DoMarkIncrementalInput() override;
 
 protected:
-	void DoGenParseCode(Output* out, Env* env, const DataPtr& data, int flags);
-	void GenDynamicSize(Output* out, Env* env, const DataPtr& data);
-	Type* DoClone() const;
+	void DoGenParseCode(Output* out, Env* env, const DataPtr& data, int flags) override;
+	void GenDynamicSize(Output* out, Env* env, const DataPtr& data) override;
+	Type* DoClone() const override;
 
 	BITType bit_type_;
 

--- a/src/pac_case.cc
+++ b/src/pac_case.cc
@@ -15,7 +15,7 @@
 CaseType::CaseType(Expr* index_expr, CaseFieldList* cases)
 	: Type(CASE), index_expr_(index_expr), cases_(cases)
 	{
-	index_var_ = 0;
+	index_var_ = nullptr;
 	foreach (i, CaseFieldList, cases_)
 		AddField(*i);
 	}
@@ -55,7 +55,7 @@ Type* CaseType::ValueType() const
 		return c->type();
 		}
 	ASSERT(0);
-	return 0;
+	return nullptr;
 	}
 
 string CaseType::DefaultValue() const
@@ -70,11 +70,11 @@ void CaseType::Prepare(Env* env, int flags)
 	index_var_ = new ID(strfmt("%s_case_index", value_var()->Name()));
 	// Unable to get the type for index_var_ at this moment, but we'll
 	// generate the right type based on index_expr_ later.
-	env->AddID(index_var_, MEMBER_VAR, 0);
+	env->AddID(index_var_, MEMBER_VAR, nullptr);
 
 	// Sort the cases_ to put the default case at the end of the list
 	CaseFieldList::iterator default_case_it = cases_->end(); // to avoid warning
-	CaseField* default_case = 0;
+	CaseField* default_case = nullptr;
 
 	foreach (i, CaseFieldList, cases_)
 		{
@@ -173,7 +173,7 @@ void CaseType::DoGenParseCode(Output* out_cc, Env* env, const DataPtr& data, int
 	foreach (i, CaseFieldList, cases_)
 		{
 		CaseField* c = *i;
-		c->GenParseCode(out_cc, env, data, compute_size_var ? size_var() : 0);
+		c->GenParseCode(out_cc, env, data, compute_size_var ? size_var() : nullptr);
 		if ( c->IsDefaultCase() )
 			has_default_case = true;
 		}
@@ -249,8 +249,8 @@ CaseField::CaseField(ExprList* index, ID* id, Type* type)
 	{
 	ASSERT(type_);
 	type_->set_value_var(id, MEMBER_VAR);
-	case_type_ = 0;
-	index_var_ = 0;
+	case_type_ = nullptr;
+	index_var_ = nullptr;
 	}
 
 CaseField::~CaseField()

--- a/src/pac_case.h
+++ b/src/pac_case.h
@@ -10,39 +10,39 @@ class CaseType : public Type
 	{
 public:
 	CaseType(Expr* index, CaseFieldList* cases);
-	~CaseType();
+	~CaseType() override;
 
 	void AddCaseField(CaseField* f);
 
-	bool DefineValueVar() const;
-	string DataTypeStr() const;
-	string DefaultValue() const;
+	bool DefineValueVar() const override;
+	string DataTypeStr() const override;
+	string DefaultValue() const override;
 
-	void Prepare(Env* env, int flags);
+	void Prepare(Env* env, int flags) override;
 
-	void GenPubDecls(Output* out, Env* env);
-	void GenPrivDecls(Output* out, Env* env);
+	void GenPubDecls(Output* out, Env* env) override;
+	void GenPrivDecls(Output* out, Env* env) override;
 
-	void GenInitCode(Output* out, Env* env);
-	void GenCleanUpCode(Output* out, Env* env);
+	void GenInitCode(Output* out, Env* env) override;
+	void GenCleanUpCode(Output* out, Env* env) override;
 
-	int StaticSize(Env* env) const;
+	int StaticSize(Env* env) const override;
 
-	void SetBoundaryChecked();
+	void SetBoundaryChecked() override;
 
 	Type* ValueType() const;
 
 	Expr* IndexExpr() const { return index_expr_; }
 
-	bool IsPointerType() const { return ValueType()->IsPointerType(); }
+	bool IsPointerType() const override { return ValueType()->IsPointerType(); }
 
 protected:
-	void DoGenParseCode(Output* out, Env* env, const DataPtr& data, int flags);
-	void GenDynamicSize(Output* out, Env* env, const DataPtr& data);
-	Type* DoClone() const { return nullptr; }
-	void DoMarkIncrementalInput();
+	void DoGenParseCode(Output* out, Env* env, const DataPtr& data, int flags) override;
+	void GenDynamicSize(Output* out, Env* env, const DataPtr& data) override;
+	Type* DoClone() const override { return nullptr; }
+	void DoMarkIncrementalInput() override;
 
-	bool ByteOrderSensitive() const;
+	bool ByteOrderSensitive() const override;
 
 	Expr* index_expr_;
 	ID* index_var_;
@@ -56,7 +56,7 @@ class CaseField : public Field
 	{
 public:
 	CaseField(ExprList* index, ID* id, Type* type);
-	~CaseField();
+	~CaseField() override;
 
 	CaseType* case_type() const { return case_type_; }
 	void set_case_type(CaseType* t) { case_type_ = t; }
@@ -68,12 +68,12 @@ public:
 	const char* CaseStr(Env* env);
 	void set_index_var(const ID* var) { index_var_ = var; }
 
-	void Prepare(Env* env);
+	void Prepare(Env* env) override;
 
-	void GenPubDecls(Output* out, Env* env);
+	void GenPubDecls(Output* out, Env* env) override;
 
-	void GenInitCode(Output* out, Env* env);
-	void GenCleanUpCode(Output* out, Env* env);
+	void GenInitCode(Output* out, Env* env) override;
+	void GenCleanUpCode(Output* out, Env* env) override;
 	void GenParseCode(Output* out, Env* env, const DataPtr& data, const ID* size_var);
 
 	int StaticSize(Env* env) const { return type_->StaticSize(env); }
@@ -82,10 +82,10 @@ public:
 	void SetBoundaryChecked() { type_->SetBoundaryChecked(); }
 
 	bool RequiresByteOrder() const { return type_->RequiresByteOrder(); }
-	bool RequiresAnalyzerContext() const;
+	bool RequiresAnalyzerContext() const override;
 
 protected:
-	bool DoTraverse(DataDepVisitor* visitor);
+	bool DoTraverse(DataDepVisitor* visitor) override;
 
 protected:
 	CaseType* case_type_;

--- a/src/pac_case.h
+++ b/src/pac_case.h
@@ -39,7 +39,7 @@ public:
 protected:
 	void DoGenParseCode(Output* out, Env* env, const DataPtr& data, int flags);
 	void GenDynamicSize(Output* out, Env* env, const DataPtr& data);
-	Type* DoClone() const { return 0; }
+	Type* DoClone() const { return nullptr; }
 	void DoMarkIncrementalInput();
 
 	bool ByteOrderSensitive() const;

--- a/src/pac_conn.cc
+++ b/src/pac_conn.cc
@@ -13,9 +13,9 @@
 ConnDecl::ConnDecl(ID* conn_id, ParamList* params, AnalyzerElementList* elemlist)
 	: AnalyzerDecl(conn_id, CONN, params)
 	{
-	flows_[0] = flows_[1] = 0;
+	flows_[0] = flows_[1] = nullptr;
 	AddElements(elemlist);
-	data_type_ = new ParameterizedType(conn_id->clone(), 0);
+	data_type_ = new ParameterizedType(conn_id->clone(), nullptr);
 	}
 
 ConnDecl::~ConnDecl()
@@ -92,7 +92,7 @@ void ConnDecl::GenEOFFunc(Output* out_h, Output* out_cc)
 
 	foreach (i, AnalyzerHelperList, eof_helpers_)
 		{
-		(*i)->GenCode(0, out_cc, this);
+		(*i)->GenCode(nullptr, out_cc, this);
 		}
 
 	out_cc->dec_indent();

--- a/src/pac_conn.h
+++ b/src/pac_conn.h
@@ -8,24 +8,24 @@ class ConnDecl : public AnalyzerDecl
 	{
 public:
 	ConnDecl(ID* conn_id, ParamList* params, AnalyzerElementList* elemlist);
-	~ConnDecl();
+	~ConnDecl() override;
 
-	void Prepare();
+	void Prepare() override;
 
 	Type* DataType() const { return data_type_; }
 
 protected:
-	void AddBaseClass(vector<string>* base_classes) const;
+	void AddBaseClass(vector<string>* base_classes) const override;
 
-	void GenProcessFunc(Output* out_h, Output* out_cc);
-	void GenGapFunc(Output* out_h, Output* out_cc);
-	void GenEOFFunc(Output* out_h, Output* out_cc);
+	void GenProcessFunc(Output* out_h, Output* out_cc) override;
+	void GenGapFunc(Output* out_h, Output* out_cc) override;
+	void GenEOFFunc(Output* out_h, Output* out_cc) override;
 
-	void GenPubDecls(Output* out_h, Output* out_cc);
-	void GenPrivDecls(Output* out_h, Output* out_cc);
+	void GenPubDecls(Output* out_h, Output* out_cc) override;
+	void GenPrivDecls(Output* out_h, Output* out_cc) override;
 
-	void ProcessFlowElement(AnalyzerFlow* flow_elem);
-	void ProcessDataUnitElement(AnalyzerDataUnit* dataunit_elem);
+	void ProcessFlowElement(AnalyzerFlow* flow_elem) override;
+	void ProcessDataUnitElement(AnalyzerDataUnit* dataunit_elem) override;
 
 	AnalyzerFlow* flows_[2];
 	Type* data_type_;

--- a/src/pac_context.cc
+++ b/src/pac_context.cc
@@ -16,7 +16,7 @@ ContextField::ContextField(ID* id, Type* type)
 	{
 	}
 
-AnalyzerContextDecl* AnalyzerContextDecl::current_analyzer_context_ = 0;
+AnalyzerContextDecl* AnalyzerContextDecl::current_analyzer_context_ = nullptr;
 
 namespace
 	{
@@ -38,7 +38,7 @@ AnalyzerContextDecl::AnalyzerContextDecl(ID* id, ContextFieldList* context_field
                new DummyType())
 	{
 	context_name_id_ = id;
-	if ( current_analyzer_context_ != 0 )
+	if ( current_analyzer_context_ != nullptr )
 		{
 		throw Exception(this, strfmt("multiple declaration of analyzer context; "
 		                             "the previous one is `%s'",
@@ -49,7 +49,7 @@ AnalyzerContextDecl::AnalyzerContextDecl(ID* id, ContextFieldList* context_field
 
 	context_fields_ = context_fields;
 
-	param_type_ = new ParameterizedType(id_->clone(), 0);
+	param_type_ = new ParameterizedType(id_->clone(), nullptr);
 
 	flow_buffer_added_ = false;
 

--- a/src/pac_context.h
+++ b/src/pac_context.h
@@ -33,7 +33,7 @@ class AnalyzerContextDecl : public TypeDecl
 	{
 public:
 	AnalyzerContextDecl(ID* id, ContextFieldList* context_fields);
-	~AnalyzerContextDecl();
+	~AnalyzerContextDecl() override;
 
 	void AddFlowBuffer();
 
@@ -42,8 +42,8 @@ public:
 	// The type of analyzer context as a parameter
 	ParameterizedType* param_type() const { return param_type_; }
 
-	void GenForwardDeclaration(Output* out_h);
-	void GenCode(Output* out_h, Output* out_cc);
+	void GenForwardDeclaration(Output* out_h) override;
+	void GenCode(Output* out_h, Output* out_cc) override;
 
 	void GenNamespaceBegin(Output* out) const;
 	void GenNamespaceEnd(Output* out) const;
@@ -69,35 +69,38 @@ class DummyType : public Type
 public:
 	DummyType() : Type(DUMMY) { }
 
-	bool DefineValueVar() const { return false; }
-	string DataTypeStr() const
+	bool DefineValueVar() const override { return false; }
+	string DataTypeStr() const override
 		{
 		ASSERT(0);
 		return "";
 		}
 
-	int StaticSize(Env* env) const
+	int StaticSize(Env* env) const override
 		{
 		ASSERT(0);
 		return -1;
 		}
 
-	bool ByteOrderSensitive() const { return false; }
+	bool ByteOrderSensitive() const override { return false; }
 
-	bool IsPointerType() const
+	bool IsPointerType() const override
 		{
 		ASSERT(0);
 		return false;
 		}
 
-	void DoGenParseCode(Output* out, Env* env, const DataPtr& data, int flags) { ASSERT(0); }
+	void DoGenParseCode(Output* out, Env* env, const DataPtr& data, int flags) override
+		{
+		ASSERT(0);
+		}
 
 	// Generate code for computing the dynamic size of the type
-	void GenDynamicSize(Output* out, Env* env, const DataPtr& data) { ASSERT(0); }
+	void GenDynamicSize(Output* out, Env* env, const DataPtr& data) override { ASSERT(0); }
 
 protected:
-	Type* DoClone() const;
-	void DoMarkIncrementalInput() { ASSERT(0); }
+	Type* DoClone() const override;
+	void DoMarkIncrementalInput() override { ASSERT(0); }
 	};
 
 #endif // pac_context_h

--- a/src/pac_datadep.h
+++ b/src/pac_datadep.h
@@ -56,8 +56,8 @@ public:
 	RequiresAnalyzerContext() : requires_analyzer_context_(false) { }
 
 	// Returns whether to continue traversal
-	bool PreProcess(DataDepElement* element);
-	bool PostProcess(DataDepElement* element);
+	bool PreProcess(DataDepElement* element) override;
+	bool PostProcess(DataDepElement* element) override;
 
 	bool requires_analyzer_context() const { return requires_analyzer_context_; }
 

--- a/src/pac_dataunit.h
+++ b/src/pac_dataunit.h
@@ -15,7 +15,7 @@ public:
 		FLOWUNIT
 		};
 	AnalyzerDataUnit(DataUnitType type, ID* id, ExprList* type_params, ExprList* context_params);
-	~AnalyzerDataUnit();
+	~AnalyzerDataUnit() override;
 
 	void Prepare(Env* env);
 

--- a/src/pac_decl.cc
+++ b/src/pac_decl.cc
@@ -14,10 +14,10 @@
 #include "pac_type.h"
 #include "pac_utils.h"
 
-DeclList* Decl::decl_list_ = 0;
+DeclList* Decl::decl_list_ = nullptr;
 Decl::DeclMap Decl::decl_map_;
 
-Decl::Decl(ID* id, DeclType decl_type) : id_(id), decl_type_(decl_type), attrlist_(0)
+Decl::Decl(ID* id, DeclType decl_type) : id_(id), decl_type_(decl_type), attrlist_(nullptr)
 	{
 	decl_map_[id_] = this;
 	if ( ! decl_list_ )
@@ -26,7 +26,7 @@ Decl::Decl(ID* id, DeclType decl_type) : id_(id), decl_type_(decl_type), attrlis
 
 	DEBUG_MSG("Finished Decl %s\n", id_->Name());
 
-	analyzer_context_ = 0;
+	analyzer_context_ = nullptr;
 	}
 
 Decl::~Decl()
@@ -119,7 +119,7 @@ Decl* Decl::LookUpDecl(const ID* id)
 	{
 	DeclMap::iterator it = decl_map_.find(id);
 	if ( it == decl_map_.end() )
-		return 0;
+		return nullptr;
 	return it->second;
 	}
 

--- a/src/pac_decl.h
+++ b/src/pac_decl.h
@@ -30,7 +30,7 @@ public:
 	AnalyzerContextDecl* analyzer_context() const { return analyzer_context_; }
 
 	// NULL except for TypeDecl or AnalyzerDecl
-	virtual Env* env() const { return 0; }
+	virtual Env* env() const { return nullptr; }
 
 	virtual void Prepare() = 0;
 

--- a/src/pac_decl.h
+++ b/src/pac_decl.h
@@ -76,14 +76,14 @@ public:
 		EXTERN,
 		};
 	HelperDecl(HelperType type, ID* context_id, EmbeddedCode* code);
-	~HelperDecl();
+	~HelperDecl() override;
 
-	void Prepare();
-	void GenExternDeclaration(Output* out_h);
-	void GenForwardDeclaration(Output* out_h)
+	void Prepare() override;
+	void GenExternDeclaration(Output* out_h) override;
+	void GenForwardDeclaration(Output* out_h) override
 		{ /* do nothing */
 		}
-	void GenCode(Output* out_h, Output* out_cc);
+	void GenCode(Output* out_h, Output* out_cc) override;
 
 private:
 	HelperType helper_type_;

--- a/src/pac_embedded.cc
+++ b/src/pac_embedded.cc
@@ -4,7 +4,7 @@
 #include "pac_output.h"
 #include "pac_primitive.h"
 
-EmbeddedCodeSegment::EmbeddedCodeSegment(const string& s) : s_(s), primitive_(0) { }
+EmbeddedCodeSegment::EmbeddedCodeSegment(const string& s) : s_(s), primitive_(nullptr) { }
 
 EmbeddedCodeSegment::EmbeddedCodeSegment(PacPrimitive* primitive)
 	: s_(""), primitive_(primitive) { }

--- a/src/pac_enum.cc
+++ b/src/pac_enum.cc
@@ -32,7 +32,7 @@ EnumDecl::EnumDecl(ID* id, EnumList* enumlist) : Decl(id, ENUM), enumlist_(enuml
 	{
 	ID* type_id = id->clone();
 	datatype_ = new ExternType(type_id, ExternType::NUMBER);
-	extern_typedecl_ = new TypeDecl(type_id, 0, datatype_);
+	extern_typedecl_ = new TypeDecl(type_id, nullptr, datatype_);
 	}
 
 EnumDecl::~EnumDecl()

--- a/src/pac_enum.h
+++ b/src/pac_enum.h
@@ -20,13 +20,13 @@ class EnumDecl : public Decl
 	{
 public:
 	EnumDecl(ID* id, EnumList* enumlist);
-	~EnumDecl();
+	~EnumDecl() override;
 
 	Type* DataType() const { return datatype_; }
 
-	void Prepare();
-	void GenForwardDeclaration(Output* out_h);
-	void GenCode(Output* out_h, Output* out_cc);
+	void Prepare() override;
+	void GenForwardDeclaration(Output* out_h) override;
+	void GenCode(Output* out_h, Output* out_cc) override;
 
 private:
 	EnumList* enumlist_;

--- a/src/pac_expr.cc
+++ b/src/pac_expr.cc
@@ -53,16 +53,16 @@ static const char* expr_fmt[] = {
 
 void Expr::init()
 	{
-	id_ = 0;
-	num_ = 0;
-	cstr_ = 0;
-	regex_ = 0;
+	id_ = nullptr;
+	num_ = nullptr;
+	cstr_ = nullptr;
+	regex_ = nullptr;
 	num_operands_ = 0;
-	operand_[0] = 0;
-	operand_[1] = 0;
-	operand_[2] = 0;
-	args_ = 0;
-	cases_ = 0;
+	operand_[0] = nullptr;
+	operand_[1] = nullptr;
+	operand_[2] = nullptr;
+	args_ = nullptr;
+	cases_ = nullptr;
 	}
 
 Expr::Expr(ID* arg_id) : DataDepElement(EXPR)
@@ -117,7 +117,7 @@ Expr::Expr(ExprType arg_type, Expr* op1, Expr* op2) : DataDepElement(EXPR)
 	num_operands_ = 2;
 	operand_[0] = op1;
 	operand_[1] = op2;
-	operand_[2] = 0;
+	operand_[2] = nullptr;
 	orig_ = strfmt(expr_fmt[expr_type_], op1->orig(), op2->orig());
 	}
 
@@ -244,7 +244,7 @@ void Expr::GenCaseEval(Output* out_cc, Env* env)
 	out_cc->inc_indent();
 	out_cc->println("{");
 
-	CaseExpr* default_case = 0;
+	CaseExpr* default_case = nullptr;
 	foreach (i, CaseExprList, cases_)
 		{
 		CaseExpr* c = *i;
@@ -266,7 +266,7 @@ void Expr::GenCaseEval(Output* out_cc, Env* env)
 		}
 
 	// Generate the default case after all other cases
-	GenCaseStr(0, out_cc, env, switch_type);
+	GenCaseStr(nullptr, out_cc, env, switch_type);
 	out_cc->inc_indent();
 	if ( default_case )
 		{
@@ -351,14 +351,14 @@ void Expr::GenEval(Output* out_cc, Env* env)
 
 			try
 				{
-				if ( (rf = GetRecordField(id, env)) != 0 )
+				if ( (rf = GetRecordField(id, env)) != nullptr )
 					{
 					str_ = strfmt("%s", rf->FieldSize(out_cc, env));
 					}
 				}
 			catch ( ExceptionIDNotFound& e )
 				{
-				if ( (ty = TypeDecl::LookUpType(id)) != 0 )
+				if ( (ty = TypeDecl::LookUpType(id)) != nullptr )
 					{
 					int ty_size = ty->StaticSize(global_env());
 					if ( ty_size >= 0 )
@@ -461,7 +461,7 @@ Type* Expr::DataType(Env* env) const
 			// Get type of the parent
 			Type* parent_type = operand_[0]->DataType(env);
 			if ( ! parent_type )
-				return 0;
+				return nullptr;
 			data_type = parent_type->MemberDataType(operand_[1]->id());
 			}
 			break;
@@ -501,7 +501,7 @@ Type* Expr::DataType(Env* env) const
 			if ( cases_ && ! cases_->empty() )
 				{
 				Type* type1 = cases_->front()->value()->DataType(env);
-				Type* numeric_with_largest_width = 0;
+				Type* numeric_with_largest_width = nullptr;
 
 				foreach (i, CaseExprList, cases_)
 					{
@@ -544,7 +544,7 @@ Type* Expr::DataType(Env* env) const
 				data_type = numeric_with_largest_width ? numeric_with_largest_width : type1;
 				}
 			else
-				data_type = 0;
+				data_type = nullptr;
 			}
 			break;
 
@@ -575,7 +575,7 @@ Type* Expr::DataType(Env* env) const
 			break;
 
 		default:
-			data_type = 0;
+			data_type = nullptr;
 			break;
 		}
 
@@ -812,7 +812,7 @@ int Expr::MinimalHeaderSize(Env* env)
 			RecordField* rf;
 			Type* ty;
 
-			if ( (rf = GetRecordField(id, env)) != 0 )
+			if ( (rf = GetRecordField(id, env)) != nullptr )
 				{
 				if ( rf->StaticSize(env, -1) >= 0 )
 					mhs = 0;
@@ -820,7 +820,7 @@ int Expr::MinimalHeaderSize(Env* env)
 					mhs = mhs_recordfield(env, rf);
 				}
 
-			else if ( (ty = TypeDecl::LookUpType(id)) != 0 )
+			else if ( (ty = TypeDecl::LookUpType(id)) != nullptr )
 				{
 				mhs = 0;
 				}

--- a/src/pac_expr.h
+++ b/src/pac_expr.h
@@ -29,7 +29,7 @@ public:
 	Expr(ExprType type, Expr* op1, Expr* op2);
 	Expr(ExprType type, Expr* op1, Expr* op2, Expr* op3);
 
-	virtual ~Expr();
+	~Expr() override;
 
 	const char* orig() const { return orig_.c_str(); }
 	const ID* id() const { return id_; }
@@ -89,7 +89,7 @@ public:
 	bool RequiresAnalyzerContext() const;
 
 protected:
-	bool DoTraverse(DataDepVisitor* visitor);
+	bool DoTraverse(DataDepVisitor* visitor) override;
 
 private:
 	ExprType expr_type_;
@@ -121,7 +121,7 @@ class CaseExpr : public Object, public DataDepElement
 	{
 public:
 	CaseExpr(ExprList* index, Expr* value);
-	virtual ~CaseExpr();
+	~CaseExpr() override;
 
 	ExprList* index() const { return index_; }
 	Expr* value() const { return value_; }
@@ -130,7 +130,7 @@ public:
 	bool RequiresAnalyzerContext() const;
 
 protected:
-	bool DoTraverse(DataDepVisitor* visitor);
+	bool DoTraverse(DataDepVisitor* visitor) override;
 
 private:
 	ExprList* index_;

--- a/src/pac_exttype.cc
+++ b/src/pac_exttype.cc
@@ -42,8 +42,10 @@ string ExternType::EvalMember(const ID* member_id) const
 
 void ExternType::GenInitCode(Output* out_cc, Env* env)
 	{
-	if ( IsNumericType() || IsPointerType() )
+	if ( IsNumericType() )
 		out_cc->println("%s = 0;", env->LValue(value_var()));
+	else if ( IsPointerType() )
+		out_cc->println("%s = nullptr;", env->LValue(value_var()));
 
 	Type::GenInitCode(out_cc, env);
 	}

--- a/src/pac_exttype.h
+++ b/src/pac_exttype.h
@@ -19,22 +19,22 @@ public:
 		};
 	ExternType(const ID* id, EXTType ext_type) : Type(EXTERN), id_(id), ext_type_(ext_type) { }
 
-	bool DefineValueVar() const;
-	string DataTypeStr() const;
-	int StaticSize(Env* env) const;
-	bool ByteOrderSensitive() const;
+	bool DefineValueVar() const override;
+	string DataTypeStr() const override;
+	int StaticSize(Env* env) const override;
+	bool ByteOrderSensitive() const override;
 
-	string EvalMember(const ID* member_id) const;
-	bool IsNumericType() const { return ext_type_ == NUMBER; }
-	bool IsPointerType() const { return ext_type_ == POINTER; }
+	string EvalMember(const ID* member_id) const override;
+	bool IsNumericType() const override { return ext_type_ == NUMBER; }
+	bool IsPointerType() const override { return ext_type_ == POINTER; }
 
-	void GenInitCode(Output* out_cc, Env* env);
+	void GenInitCode(Output* out_cc, Env* env) override;
 
 protected:
-	void DoGenParseCode(Output* out, Env* env, const DataPtr& data, int flags);
-	void GenDynamicSize(Output* out, Env* env, const DataPtr& data);
+	void DoGenParseCode(Output* out, Env* env, const DataPtr& data, int flags) override;
+	void GenDynamicSize(Output* out, Env* env, const DataPtr& data) override;
 
-	Type* DoClone() const;
+	Type* DoClone() const override;
 
 private:
 	const ID* id_;

--- a/src/pac_field.cc
+++ b/src/pac_field.cc
@@ -11,7 +11,7 @@ Field::Field(FieldType tof, int flags, ID* id, Type* type)
 	{
 	decl_id_ = current_decl_id;
 	field_id_str_ = strfmt("%s:%s", decl_id()->Name(), id_->Name());
-	attrs_ = 0;
+	attrs_ = nullptr;
 	}
 
 Field::~Field()

--- a/src/pac_field.h
+++ b/src/pac_field.h
@@ -42,7 +42,7 @@ public:
 	static const int PUBLIC_READABLE = 4;
 	static const int NOT_PUBLIC_READABLE = 0;
 
-	virtual ~Field();
+	~Field() override;
 
 	FieldType tof() const { return tof_; }
 	const ID* id() const { return id_; }
@@ -70,7 +70,7 @@ protected:
 	int ValueVarType() const;
 	bool ToBeParsed() const;
 
-	bool DoTraverse(DataDepVisitor* visitor);
+	bool DoTraverse(DataDepVisitor* visitor) override;
 
 protected:
 	FieldType tof_;

--- a/src/pac_flow.cc
+++ b/src/pac_flow.cc
@@ -113,8 +113,8 @@ void FlowDecl::GenInitCode(Output* out_cc)
 	{
 	AnalyzerDecl::GenInitCode(out_cc);
 
-	out_cc->println("%s = 0;", env_->LValue(dataunit_id));
-	out_cc->println("%s = 0;", env_->LValue(analyzer_context_id));
+	out_cc->println("%s = nullptr;", env_->LValue(dataunit_id));
+	out_cc->println("%s = nullptr;", env_->LValue(analyzer_context_id));
 
 	if ( dataunit_->type() == AnalyzerDataUnit::FLOWUNIT )
 		{
@@ -147,7 +147,7 @@ void FlowDecl::GenEOFFunc(Output* out_h, Output* out_cc)
 	if ( dataunit_->type() == AnalyzerDataUnit::FLOWUNIT )
 		{
 		out_cc->println("%s->set_eof();", env_->LValue(flow_buffer_id));
-		out_cc->println("%s(0, 0);", kNewData);
+		out_cc->println("%s(nullptr, nullptr);", kNewData);
 		}
 
 	out_cc->println("}");

--- a/src/pac_flow.cc
+++ b/src/pac_flow.cc
@@ -18,9 +18,9 @@
 FlowDecl::FlowDecl(ID* id, ParamList* params, AnalyzerElementList* elemlist)
 	: AnalyzerDecl(id, FLOW, params)
 	{
-	dataunit_ = 0;
-	conn_decl_ = 0;
-	flow_buffer_var_field_ = 0;
+	dataunit_ = nullptr;
+	conn_decl_ = nullptr;
+	flow_buffer_var_field_ = nullptr;
 	AddElements(elemlist);
 	}
 
@@ -30,13 +30,13 @@ FlowDecl::~FlowDecl()
 	delete dataunit_;
 	}
 
-ParameterizedType* FlowDecl::flow_buffer_type_ = 0;
+ParameterizedType* FlowDecl::flow_buffer_type_ = nullptr;
 
 ParameterizedType* FlowDecl::flow_buffer_type()
 	{
 	if ( ! flow_buffer_type_ )
 		{
-		flow_buffer_type_ = new ParameterizedType(new ID(kFlowBufferClass), 0);
+		flow_buffer_type_ = new ParameterizedType(new ID(kFlowBufferClass), nullptr);
 		}
 	return flow_buffer_type_;
 	}
@@ -141,7 +141,7 @@ void FlowDecl::GenEOFFunc(Output* out_h, Output* out_cc)
 
 	foreach (i, AnalyzerHelperList, eof_helpers_)
 		{
-		(*i)->GenCode(0, out_cc, this);
+		(*i)->GenCode(nullptr, out_cc, this);
 		}
 
 	if ( dataunit_->type() == AnalyzerDataUnit::FLOWUNIT )
@@ -268,7 +268,7 @@ void FlowDecl::GenCodeFlowUnit(Output* out_cc)
 	out_cc->println("}");
 	out_cc->dec_indent();
 
-	DataPtr data(env_, 0, 0);
+	DataPtr data(env_, nullptr, 0);
 	unit_datatype->GenParseCode(out_cc, env_, data, 0);
 
 	out_cc->println("if ( %s )", unit_datatype->parsing_complete(env_).c_str());

--- a/src/pac_flow.h
+++ b/src/pac_flow.h
@@ -7,28 +7,28 @@ class FlowDecl : public AnalyzerDecl
 	{
 public:
 	FlowDecl(ID* flow_id, ParamList* params, AnalyzerElementList* elemlist);
-	~FlowDecl();
+	~FlowDecl() override;
 
-	void Prepare();
+	void Prepare() override;
 
 	void set_conn_decl(ConnDecl* c) { conn_decl_ = c; }
 
 	static ParameterizedType* flow_buffer_type();
 
 protected:
-	void AddBaseClass(vector<string>* base_classes) const;
+	void AddBaseClass(vector<string>* base_classes) const override;
 
-	void GenInitCode(Output* out_cc);
-	void GenCleanUpCode(Output* out_cc);
-	void GenProcessFunc(Output* out_h, Output* out_cc);
-	void GenEOFFunc(Output* out_h, Output* out_cc);
-	void GenGapFunc(Output* out_h, Output* out_cc);
+	void GenInitCode(Output* out_cc) override;
+	void GenCleanUpCode(Output* out_cc) override;
+	void GenProcessFunc(Output* out_h, Output* out_cc) override;
+	void GenEOFFunc(Output* out_h, Output* out_cc) override;
+	void GenGapFunc(Output* out_h, Output* out_cc) override;
 
-	void GenPubDecls(Output* out_h, Output* out_cc);
-	void GenPrivDecls(Output* out_h, Output* out_cc);
+	void GenPubDecls(Output* out_h, Output* out_cc) override;
+	void GenPrivDecls(Output* out_h, Output* out_cc) override;
 
-	void ProcessFlowElement(AnalyzerFlow* flow_elem);
-	void ProcessDataUnitElement(AnalyzerDataUnit* dataunit_elem);
+	void ProcessFlowElement(AnalyzerFlow* flow_elem) override;
+	void ProcessDataUnitElement(AnalyzerDataUnit* dataunit_elem) override;
 
 private:
 	void GenNewDataUnit(Output* out_cc);

--- a/src/pac_func.cc
+++ b/src/pac_func.cc
@@ -7,10 +7,10 @@
 #include "pac_type.h"
 
 Function::Function(ID* id, Type* type, ParamList* params)
-	: id_(id), type_(type), params_(params), expr_(0), code_(0)
+	: id_(id), type_(type), params_(params), expr_(nullptr), code_(nullptr)
 	{
-	analyzer_decl_ = 0;
-	env_ = 0;
+	analyzer_decl_ = nullptr;
+	env_ = nullptr;
 	}
 
 Function::~Function()

--- a/src/pac_func.h
+++ b/src/pac_func.h
@@ -42,13 +42,13 @@ class FuncDecl : public Decl
 	{
 public:
 	FuncDecl(Function* function);
-	~FuncDecl();
+	~FuncDecl() override;
 
 	Function* function() const { return function_; }
 
-	void Prepare();
-	void GenForwardDeclaration(Output* out_h);
-	void GenCode(Output* out_h, Output* out_cc);
+	void Prepare() override;
+	void GenForwardDeclaration(Output* out_h) override;
+	void GenCode(Output* out_h, Output* out_cc) override;
 
 private:
 	Function* function_;

--- a/src/pac_id.cc
+++ b/src/pac_id.cc
@@ -7,34 +7,34 @@
 #include "pac_type.h"
 #include "pac_utils.h"
 
-const ID* default_value_var = 0;
-const ID* null_id = 0;
-const ID* null_byteseg_id = 0;
-const ID* null_decl_id = 0;
-const ID* begin_of_data = 0;
-const ID* end_of_data = 0;
-const ID* len_of_data = 0;
-const ID* byteorder_id = 0;
-const ID* bigendian_id = 0;
-const ID* littleendian_id = 0;
-const ID* unspecified_byteorder_id = 0;
-const ID* const_true_id = 0;
-const ID* const_false_id = 0;
-const ID* analyzer_context_id = 0;
-const ID* context_macro_id = 0;
-const ID* this_id = 0;
-const ID* sourcedata_id = 0;
-const ID* connection_id = 0;
-const ID* upflow_id = 0;
-const ID* downflow_id = 0;
-const ID* dataunit_id = 0;
-const ID* flow_buffer_id = 0;
-const ID* element_macro_id = 0;
-const ID* input_macro_id = 0;
-const ID* cxt_connection_id = 0;
-const ID* cxt_flow_id = 0;
-const ID* parsing_state_id = 0;
-const ID* buffering_state_id = 0;
+const ID* default_value_var = nullptr;
+const ID* null_id = nullptr;
+const ID* null_byteseg_id = nullptr;
+const ID* null_decl_id = nullptr;
+const ID* begin_of_data = nullptr;
+const ID* end_of_data = nullptr;
+const ID* len_of_data = nullptr;
+const ID* byteorder_id = nullptr;
+const ID* bigendian_id = nullptr;
+const ID* littleendian_id = nullptr;
+const ID* unspecified_byteorder_id = nullptr;
+const ID* const_true_id = nullptr;
+const ID* const_false_id = nullptr;
+const ID* analyzer_context_id = nullptr;
+const ID* context_macro_id = nullptr;
+const ID* this_id = nullptr;
+const ID* sourcedata_id = nullptr;
+const ID* connection_id = nullptr;
+const ID* upflow_id = nullptr;
+const ID* downflow_id = nullptr;
+const ID* dataunit_id = nullptr;
+const ID* flow_buffer_id = nullptr;
+const ID* element_macro_id = nullptr;
+const ID* input_macro_id = nullptr;
+const ID* cxt_connection_id = nullptr;
+const ID* cxt_flow_id = nullptr;
+const ID* parsing_state_id = nullptr;
+const ID* buffering_state_id = nullptr;
 
 int ID::anonymous_id_seq = 0;
 
@@ -48,7 +48,7 @@ ID* ID::NewAnonymousID(const string& prefix)
 IDRecord::IDRecord(Env* arg_env, const ID* arg_id, IDType arg_id_type)
 	: env(arg_env), id(arg_id), id_type(arg_id_type)
 	{
-	eval = 0;
+	eval = nullptr;
 	evaluated = in_evaluation = false;
 	setfunc = ""; // except for STATE_VAR
 	switch ( id_type )
@@ -92,10 +92,10 @@ IDRecord::IDRecord(Env* arg_env, const ID* arg_id, IDType arg_id_type)
 			break;
 		}
 
-	data_type = 0;
-	field = 0;
+	data_type = nullptr;
+	field = nullptr;
 	constant = constant_set = false;
-	macro = 0;
+	macro = nullptr;
 	}
 
 IDRecord::~IDRecord() { }
@@ -157,7 +157,7 @@ void IDRecord::Evaluate(Output* out, Env* env)
 const char* IDRecord::RValue() const
 	{
 	if ( id_type == MACRO )
-		return macro->EvalExpr(0, env);
+		return macro->EvalExpr(nullptr, env);
 
 	if ( id_type == TEMP_VAR && ! evaluated )
 		throw ExceptionIDNotEvaluated(id);
@@ -239,7 +239,7 @@ IDRecord* Env::lookup(const ID* id, bool recursive, bool raise_exception) const
 	if ( raise_exception )
 		throw ExceptionIDNotFound(id);
 	else
-		return 0;
+		return nullptr;
 	}
 
 IDType Env::GetIDType(const ID* id) const
@@ -335,7 +335,7 @@ Type* Env::GetDataType(const ID* id) const
 	if ( r )
 		return r->GetDataType();
 	else
-		return 0;
+		return nullptr;
 	}
 
 string Env::DataTypeStr(const ID* id) const
@@ -406,11 +406,11 @@ void init_builtin_identifiers()
 
 Env* global_env()
 	{
-	static Env* the_global_env = 0;
+	static Env* the_global_env = nullptr;
 
 	if ( ! the_global_env )
 		{
-		the_global_env = new Env(0, 0);
+		the_global_env = new Env(nullptr, nullptr);
 
 		// These two are defined in binpac.h, so we do not need to
 		// generate code for them.

--- a/src/pac_inputbuf.h
+++ b/src/pac_inputbuf.h
@@ -15,7 +15,7 @@ public:
 	DataPtr GenDataBeginEnd(Output* out_cc, Env* env);
 
 protected:
-	bool DoTraverse(DataDepVisitor* visitor);
+	bool DoTraverse(DataDepVisitor* visitor) override;
 
 private:
 	Expr* expr_;

--- a/src/pac_let.h
+++ b/src/pac_let.h
@@ -8,20 +8,20 @@ class LetField : public Field, Evaluatable
 	{
 public:
 	LetField(ID* arg_id, Type* type, Expr* arg_expr);
-	~LetField();
+	~LetField() override;
 
 	Expr* expr() const { return expr_; }
 
-	void Prepare(Env* env);
+	void Prepare(Env* env) override;
 
-	void GenInitCode(Output* out, Env* env);
+	void GenInitCode(Output* out, Env* env) override;
 	void GenParseCode(Output* out, Env* env);
-	void GenEval(Output* out, Env* env);
+	void GenEval(Output* out, Env* env) override;
 
-	bool RequiresAnalyzerContext() const;
+	bool RequiresAnalyzerContext() const override;
 
 protected:
-	bool DoTraverse(DataDepVisitor* visitor);
+	bool DoTraverse(DataDepVisitor* visitor) override;
 
 protected:
 	Expr* expr_;
@@ -31,14 +31,14 @@ class LetDecl : public Decl, Evaluatable
 	{
 public:
 	LetDecl(ID* id, Type* type, Expr* expr);
-	~LetDecl();
+	~LetDecl() override;
 
 	Expr* expr() const { return expr_; }
 
-	void Prepare();
-	void GenForwardDeclaration(Output* out_h);
-	void GenCode(Output* out_h, Output* out_cc);
-	void GenEval(Output* out, Env* env);
+	void Prepare() override;
+	void GenForwardDeclaration(Output* out_h) override;
+	void GenCode(Output* out_h, Output* out_cc) override;
+	void GenEval(Output* out, Env* env) override;
 
 private:
 	Type* type_;

--- a/src/pac_main.cc
+++ b/src/pac_main.cc
@@ -22,8 +22,8 @@ bool FLAGS_quiet = false;
 string FLAGS_output_directory;
 vector<string> FLAGS_include_directories;
 
-Output* header_output = 0;
-Output* source_output = 0;
+Output* header_output = nullptr;
+Output* source_output = nullptr;
 
 void add_to_include_directories(string dirs)
 	{
@@ -182,8 +182,8 @@ int compile(const char* filename)
 		exit(1);
 		}
 
-	header_output = 0;
-	source_output = 0;
+	header_output = nullptr;
+	source_output = nullptr;
 	input_filename = "";
 	fclose(fp_input);
 

--- a/src/pac_param.h
+++ b/src/pac_param.h
@@ -27,8 +27,8 @@ class ParamField : public Field
 public:
 	ParamField(const Param* param);
 
-	void GenInitCode(Output* out, Env* env);
-	void GenCleanUpCode(Output* out, Env* env);
+	void GenInitCode(Output* out, Env* env) override;
+	void GenCleanUpCode(Output* out, Env* env) override;
 	};
 
 // Returns the string with a list of param declarations separated by ','.

--- a/src/pac_paramtype.cc
+++ b/src/pac_paramtype.cc
@@ -154,7 +154,7 @@ bool ParameterizedType::RequiresAnalyzerContext()
 void ParameterizedType::GenInitCode(Output* out_cc, Env* env)
 	{
 	ASSERT(persistent());
-	out_cc->println("%s = 0;", env->LValue(value_var()));
+	out_cc->println("%s = nullptr;", env->LValue(value_var()));
 	Type::GenInitCode(out_cc, env);
 	}
 
@@ -165,7 +165,7 @@ void ParameterizedType::GenCleanUpCode(Output* out_cc, Env* env)
 		out_cc->println("Unref(%s);", lvalue());
 	else
 		out_cc->println("delete %s;", lvalue());
-	out_cc->println("%s = 0;", lvalue());
+	out_cc->println("%s = nullptr;", lvalue());
 	Type::GenCleanUpCode(out_cc, env);
 	}
 
@@ -206,7 +206,7 @@ void ParameterizedType::DoGenParseCode(Output* out_cc, Env* env, const DataPtr& 
 		{
 		ASSERT(! ref_type->incremental_input());
 		parse_func = kParseFuncWithoutBuffer;
-		parse_params = "0, 0";
+		parse_params = "nullptr, nullptr";
 		}
 	else if ( ref_type->incremental_input() )
 		{

--- a/src/pac_paramtype.cc
+++ b/src/pac_paramtype.cc
@@ -50,7 +50,7 @@ Type* ParameterizedType::MemberDataType(const ID* member_id) const
 	{
 	Type* ref_type = TypeDecl::LookUpType(type_id_);
 	if ( ! ref_type )
-		return 0;
+		return nullptr;
 	return ref_type->MemberDataType(member_id);
 	}
 

--- a/src/pac_paramtype.h
+++ b/src/pac_paramtype.h
@@ -8,54 +8,54 @@ class ParameterizedType : public Type
 	{
 public:
 	ParameterizedType(ID* type_id, ExprList* args);
-	~ParameterizedType();
+	~ParameterizedType() override;
 
 	Type* clone() const;
 
-	string EvalMember(const ID* member_id) const;
+	string EvalMember(const ID* member_id) const override;
 	// Env *member_env() const;
 
 	void AddParamArg(Expr* arg);
 
-	bool DefineValueVar() const;
-	string DataTypeStr() const;
-	string DefaultValue() const { return "0"; }
-	Type* MemberDataType(const ID* member_id) const;
+	bool DefineValueVar() const override;
+	string DataTypeStr() const override;
+	string DefaultValue() const override { return "0"; }
+	Type* MemberDataType(const ID* member_id) const override;
 
 	// "throw_exception" specifies whether to throw an exception
 	// if the referred data type is not found
 	Type* ReferredDataType(bool throw_exception) const;
 
-	void GenCleanUpCode(Output* out, Env* env);
+	void GenCleanUpCode(Output* out, Env* env) override;
 
-	int StaticSize(Env* env) const;
+	int StaticSize(Env* env) const override;
 
-	bool IsPointerType() const { return true; }
+	bool IsPointerType() const override { return true; }
 
-	bool ByteOrderSensitive() const;
-	bool RequiresAnalyzerContext();
+	bool ByteOrderSensitive() const override;
+	bool RequiresAnalyzerContext() override;
 
-	void GenInitCode(Output* out_cc, Env* env);
+	void GenInitCode(Output* out_cc, Env* env) override;
 
 	string class_name() const;
 	string EvalParameters(Output* out_cc, Env* env) const;
 
-	BufferMode buffer_mode() const;
+	BufferMode buffer_mode() const override;
 
 protected:
-	void GenNewInstance(Output* out, Env* env);
+	void GenNewInstance(Output* out, Env* env) override;
 
-	bool DoTraverse(DataDepVisitor* visitor);
-	Type* DoClone() const;
-	void DoMarkIncrementalInput();
+	bool DoTraverse(DataDepVisitor* visitor) override;
+	Type* DoClone() const override;
+	void DoMarkIncrementalInput() override;
 
 private:
 	ID* type_id_;
 	ExprList* args_;
 	bool checking_requires_analyzer_context_;
 
-	void DoGenParseCode(Output* out, Env* env, const DataPtr& data, int flags);
-	void GenDynamicSize(Output* out, Env* env, const DataPtr& data);
+	void DoGenParseCode(Output* out, Env* env, const DataPtr& data, int flags) override;
+	void GenDynamicSize(Output* out, Env* env, const DataPtr& data) override;
 	};
 
 #endif // pac_paramtype_h

--- a/src/pac_primitive.cc
+++ b/src/pac_primitive.cc
@@ -8,13 +8,13 @@
 string PPVal::ToCode(Env* env)
 	{
 	ASSERT(expr_);
-	return string(expr_->EvalExpr(0, env));
+	return string(expr_->EvalExpr(nullptr, env));
 	}
 
 string PPSet::ToCode(Env* env)
 	{
 	ASSERT(expr_);
-	return expr_->SetFunc(0, env);
+	return expr_->SetFunc(nullptr, env);
 	}
 
 string PPType::ToCode(Env* env)
@@ -30,5 +30,5 @@ string PPConstDef::ToCode(Env* env)
 	env->SetEvaluated(id_);
 
 	string type_str = type->DataTypeStr();
-	return strfmt("%s %s = %s", type_str.c_str(), env->LValue(id_), expr_->EvalExpr(0, env));
+	return strfmt("%s %s = %s", type_str.c_str(), env->LValue(id_), expr_->EvalExpr(nullptr, env));
 	}

--- a/src/pac_primitive.h
+++ b/src/pac_primitive.h
@@ -31,7 +31,7 @@ public:
 	PPVal(Expr* expr) : PacPrimitive(VAL), expr_(expr) { }
 	Expr* expr() const { return expr_; }
 
-	string ToCode(Env* env);
+	string ToCode(Env* env) override;
 
 private:
 	Expr* expr_;
@@ -43,7 +43,7 @@ public:
 	PPSet(Expr* expr) : PacPrimitive(SET), expr_(expr) { }
 	Expr* expr() const { return expr_; }
 
-	string ToCode(Env* env);
+	string ToCode(Env* env) override;
 
 private:
 	Expr* expr_;
@@ -55,7 +55,7 @@ public:
 	PPType(Expr* expr) : PacPrimitive(TYPE), expr_(expr) { }
 	Expr* expr() const { return expr_; }
 
-	string ToCode(Env* env);
+	string ToCode(Env* env) override;
 
 private:
 	Expr* expr_;
@@ -68,7 +68,7 @@ public:
 	const ID* id() const { return id_; }
 	Expr* expr() const { return expr_; }
 
-	string ToCode(Env* env);
+	string ToCode(Env* env) override;
 
 private:
 	const ID* id_;

--- a/src/pac_record.cc
+++ b/src/pac_record.cc
@@ -15,7 +15,7 @@
 RecordType::RecordType(RecordFieldList* record_fields) : Type(RECORD)
 	{
 	// Here we assume that the type is a standalone type.
-	value_var_ = 0;
+	value_var_ = nullptr;
 
 	// Put all fields in fields_
 	foreach (i, RecordFieldList, record_fields)
@@ -24,7 +24,7 @@ RecordType::RecordType(RecordFieldList* record_fields) : Type(RECORD)
 	// Put RecordField's in record_fields_
 	record_fields_ = record_fields;
 
-	parsing_dataptr_var_field_ = 0;
+	parsing_dataptr_var_field_ = nullptr;
 	}
 
 RecordType::~RecordType()
@@ -37,7 +37,7 @@ RecordType::~RecordType()
 
 const ID* RecordType::parsing_dataptr_var() const
 	{
-	return parsing_dataptr_var_field_ ? parsing_dataptr_var_field_->id() : 0;
+	return parsing_dataptr_var_field_ ? parsing_dataptr_var_field_->id() : nullptr;
 	}
 
 bool RecordType::DefineValueVar() const
@@ -55,7 +55,7 @@ void RecordType::Prepare(Env* env, int flags)
 	{
 	ASSERT(flags & TO_BE_PARSED);
 
-	RecordField* prev = 0;
+	RecordField* prev = nullptr;
 	int offset = 0;
 	int seq = 0;
 	foreach (i, RecordFieldList, record_fields_)
@@ -237,14 +237,14 @@ bool RecordType::ByteOrderSensitive() const
 RecordField::RecordField(FieldType tof, ID* id, Type* type)
 	: Field(tof, TYPE_TO_BE_PARSED | CLASS_MEMBER | PUBLIC_READABLE, id, type)
 	{
-	begin_of_field_dataptr = 0;
-	end_of_field_dataptr = 0;
-	field_size_expr = 0;
-	field_offset_expr = 0;
-	end_of_field_dataptr_var = 0;
-	record_type_ = 0;
-	prev_ = 0;
-	next_ = 0;
+	begin_of_field_dataptr = nullptr;
+	end_of_field_dataptr = nullptr;
+	field_size_expr = nullptr;
+	field_offset_expr = nullptr;
+	end_of_field_dataptr_var = nullptr;
+	record_type_ = nullptr;
+	prev_ = nullptr;
+	next_ = nullptr;
 	static_offset_ = -1;
 	parsing_state_seq_ = 0;
 	boundary_checked_ = false;
@@ -399,7 +399,7 @@ void RecordDataField::GenParseCode(Output* out_cc, Env* env)
 	if ( record_type()->incremental_parsing() && prev() )
 		prev()->GenParseCode(out_cc, env);
 
-	DataPtr data(env, 0, 0);
+	DataPtr data(env, nullptr, 0);
 	if ( ! record_type()->incremental_parsing() )
 		{
 		data = getFieldBegin(out_cc, env);
@@ -499,7 +499,7 @@ bool RecordDataField::RequiresAnalyzerContext() const
 	}
 
 RecordPaddingField::RecordPaddingField(ID* id, PaddingType ptype, Expr* expr)
-	: RecordField(PADDING_FIELD, id, 0), ptype_(ptype), expr_(expr)
+	: RecordField(PADDING_FIELD, id, nullptr), ptype_(ptype), expr_(expr)
 	{
 	wordsize_ = -1;
 	}

--- a/src/pac_record.h
+++ b/src/pac_record.h
@@ -40,7 +40,7 @@ protected:
 	void DoGenParseCode(Output* out, Env* env, const DataPtr& data, int flags);
 	void GenDynamicSize(Output* out, Env* env, const DataPtr& data);
 
-	Type* DoClone() const { return 0; }
+	Type* DoClone() const { return nullptr; }
 
 	void DoMarkIncrementalInput();
 

--- a/src/pac_record.h
+++ b/src/pac_record.h
@@ -11,41 +11,41 @@ class RecordType : public Type
 	{
 public:
 	RecordType(RecordFieldList* fields);
-	~RecordType();
+	~RecordType() override;
 
-	bool DefineValueVar() const;
-	string DataTypeStr() const;
+	bool DefineValueVar() const override;
+	string DataTypeStr() const override;
 
-	void Prepare(Env* env, int flags);
+	void Prepare(Env* env, int flags) override;
 
-	void GenPubDecls(Output* out, Env* env);
-	void GenPrivDecls(Output* out, Env* env);
+	void GenPubDecls(Output* out, Env* env) override;
+	void GenPrivDecls(Output* out, Env* env) override;
 
-	void GenInitCode(Output* out, Env* env);
-	void GenCleanUpCode(Output* out, Env* env);
+	void GenInitCode(Output* out, Env* env) override;
+	void GenCleanUpCode(Output* out, Env* env) override;
 
-	int StaticSize(Env* env) const;
+	int StaticSize(Env* env) const override;
 
-	void SetBoundaryChecked();
+	void SetBoundaryChecked() override;
 
 	const ID* parsing_dataptr_var() const;
 
-	bool IsPointerType() const
+	bool IsPointerType() const override
 		{
 		ASSERT(0);
 		return false;
 		}
 
 protected:
-	void DoGenParseCode(Output* out, Env* env, const DataPtr& data, int flags);
-	void GenDynamicSize(Output* out, Env* env, const DataPtr& data);
+	void DoGenParseCode(Output* out, Env* env, const DataPtr& data, int flags) override;
+	void GenDynamicSize(Output* out, Env* env, const DataPtr& data) override;
 
-	Type* DoClone() const { return nullptr; }
+	Type* DoClone() const override { return nullptr; }
 
-	void DoMarkIncrementalInput();
+	void DoMarkIncrementalInput() override;
 
-	bool DoTraverse(DataDepVisitor* visitor);
-	bool ByteOrderSensitive() const;
+	bool DoTraverse(DataDepVisitor* visitor) override;
+	bool ByteOrderSensitive() const override;
 
 private:
 	Field* parsing_dataptr_var_field_;
@@ -60,7 +60,7 @@ class RecordField : public Field
 	{
 public:
 	RecordField(FieldType tof, ID* id, Type* type);
-	~RecordField();
+	~RecordField() override;
 
 	RecordType* record_type() const { return record_type_; }
 	void set_record_type(RecordType* ty) { record_type_ = ty; }
@@ -115,26 +115,26 @@ class RecordDataField : public RecordField, public Evaluatable
 	{
 public:
 	RecordDataField(ID* arg_id, Type* arg_type);
-	~RecordDataField();
+	~RecordDataField() override;
 
 	// Instantiates abstract class Field
-	void Prepare(Env* env);
-	void GenParseCode(Output* out, Env* env);
+	void Prepare(Env* env) override;
+	void GenParseCode(Output* out, Env* env) override;
 
 	// Instantiates abstract class Evaluatable
-	void GenEval(Output* out, Env* env);
+	void GenEval(Output* out, Env* env) override;
 
-	int StaticSize(Env* env, int) const { return type()->StaticSize(env); }
+	int StaticSize(Env* env, int) const override { return type()->StaticSize(env); }
 
-	void SetBoundaryChecked();
+	void SetBoundaryChecked() override;
 
-	bool RequiresByteOrder() const { return type()->RequiresByteOrder(); }
-	bool RequiresAnalyzerContext() const;
+	bool RequiresByteOrder() const override { return type()->RequiresByteOrder(); }
+	bool RequiresAnalyzerContext() const override;
 
 protected:
-	void GenFieldEnd(Output* out, Env* env, const DataPtr& begin);
-	bool GenBoundaryCheck(Output* out_cc, Env* env);
-	bool DoTraverse(DataDepVisitor* visitor);
+	void GenFieldEnd(Output* out, Env* env, const DataPtr& begin) override;
+	bool GenBoundaryCheck(Output* out_cc, Env* env) override;
+	bool DoTraverse(DataDepVisitor* visitor) override;
 	};
 
 enum PaddingType
@@ -148,33 +148,33 @@ class RecordPaddingField : public RecordField
 	{
 public:
 	RecordPaddingField(ID* id, PaddingType ptype, Expr* expr);
-	~RecordPaddingField();
+	~RecordPaddingField() override;
 
-	void Prepare(Env* env);
+	void Prepare(Env* env) override;
 
-	void GenPubDecls(Output* out, Env* env)
+	void GenPubDecls(Output* out, Env* env) override
 		{ /* nothing */
 		}
-	void GenPrivDecls(Output* out, Env* env)
+	void GenPrivDecls(Output* out, Env* env) override
 		{ /* nothing */
 		}
 
-	void GenInitCode(Output* out, Env* env)
+	void GenInitCode(Output* out, Env* env) override
 		{ /* nothing */
 		}
-	void GenCleanUpCode(Output* out, Env* env)
+	void GenCleanUpCode(Output* out, Env* env) override
 		{ /* nothing */
 		}
-	void GenParseCode(Output* out, Env* env);
+	void GenParseCode(Output* out, Env* env) override;
 
-	int StaticSize(Env* env, int offset) const;
+	int StaticSize(Env* env, int offset) const override;
 
-	bool RequiresByteOrder() const { return false; }
+	bool RequiresByteOrder() const override { return false; }
 
 protected:
-	void GenFieldEnd(Output* out, Env* env, const DataPtr& begin);
-	bool GenBoundaryCheck(Output* out_cc, Env* env);
-	bool DoTraverse(DataDepVisitor* visitor);
+	void GenFieldEnd(Output* out, Env* env, const DataPtr& begin) override;
+	bool GenBoundaryCheck(Output* out_cc, Env* env) override;
+	bool DoTraverse(DataDepVisitor* visitor) override;
 
 private:
 	PaddingType ptype_;

--- a/src/pac_regex.h
+++ b/src/pac_regex.h
@@ -30,9 +30,9 @@ class RegExDecl : public Decl
 public:
 	RegExDecl(RegEx* regex);
 
-	void Prepare();
-	void GenForwardDeclaration(Output* out_h);
-	void GenCode(Output* out_h, Output* out_cc);
+	void Prepare() override;
+	void GenForwardDeclaration(Output* out_h) override;
+	void GenCode(Output* out_h, Output* out_cc) override;
 
 private:
 	RegEx* regex_;

--- a/src/pac_strtype.cc
+++ b/src/pac_strtype.cc
@@ -15,18 +15,19 @@
 const char* StringType::kStringTypeName = "bytestring";
 const char* StringType::kConstStringTypeName = "const_bytestring";
 
-StringType::StringType(StringTypeEnum anystr) : Type(STRING), type_(ANYSTR), str_(0), regex_(0)
+StringType::StringType(StringTypeEnum anystr)
+	: Type(STRING), type_(ANYSTR), str_(nullptr), regex_(nullptr)
 	{
 	ASSERT(anystr == ANYSTR);
 	init();
 	}
 
-StringType::StringType(ConstString* str) : Type(STRING), type_(CSTR), str_(str), regex_(0)
+StringType::StringType(ConstString* str) : Type(STRING), type_(CSTR), str_(str), regex_(nullptr)
 	{
 	init();
 	}
 
-StringType::StringType(RegEx* regex) : Type(STRING), type_(REGEX), str_(0), regex_(regex)
+StringType::StringType(RegEx* regex) : Type(STRING), type_(REGEX), str_(nullptr), regex_(regex)
 	{
 	ASSERT(regex_);
 	init();
@@ -34,7 +35,7 @@ StringType::StringType(RegEx* regex) : Type(STRING), type_(REGEX), str_(0), rege
 
 void StringType::init()
 	{
-	string_length_var_field_ = 0;
+	string_length_var_field_ = nullptr;
 	elem_datatype_ = new BuiltInType(BuiltInType::UINT8);
 	}
 
@@ -67,7 +68,7 @@ Type* StringType::DoClone() const
 			break;
 		default:
 			ASSERT(0);
-			return 0;
+			return nullptr;
 		}
 
 	return clone;
@@ -206,7 +207,7 @@ int StringType::StaticSize(Env* env) const
 
 const ID* StringType::string_length_var() const
 	{
-	return string_length_var_field_ ? string_length_var_field_->id() : 0;
+	return string_length_var_field_ ? string_length_var_field_->id() : nullptr;
 	}
 
 void StringType::GenDynamicSize(Output* out_cc, Env* env, const DataPtr& data)

--- a/src/pac_strtype.h
+++ b/src/pac_strtype.h
@@ -17,28 +17,28 @@ public:
 	explicit StringType(StringTypeEnum anystr);
 	explicit StringType(ConstString* str);
 	explicit StringType(RegEx* regex);
-	~StringType();
+	~StringType() override;
 
-	bool DefineValueVar() const;
-	string DataTypeStr() const;
-	string DefaultValue() const { return "0"; }
-	Type* ElementDataType() const;
+	bool DefineValueVar() const override;
+	string DataTypeStr() const override;
+	string DefaultValue() const override { return "0"; }
+	Type* ElementDataType() const override;
 
-	void Prepare(Env* env, int flags);
+	void Prepare(Env* env, int flags) override;
 
-	void GenPubDecls(Output* out, Env* env);
-	void GenPrivDecls(Output* out, Env* env);
+	void GenPubDecls(Output* out, Env* env) override;
+	void GenPrivDecls(Output* out, Env* env) override;
 
-	void GenInitCode(Output* out, Env* env);
-	void GenCleanUpCode(Output* out, Env* env);
+	void GenInitCode(Output* out, Env* env) override;
+	void GenCleanUpCode(Output* out, Env* env) override;
 
-	void DoMarkIncrementalInput();
+	void DoMarkIncrementalInput() override;
 
-	int StaticSize(Env* env) const;
+	int StaticSize(Env* env) const override;
 
-	bool IsPointerType() const { return false; }
+	bool IsPointerType() const override { return false; }
 
-	void ProcessAttr(Attr* a);
+	void ProcessAttr(Attr* a) override;
 
 protected:
 	void init();
@@ -50,21 +50,21 @@ protected:
 	// Generate a string mismatch exception
 	void GenStringMismatch(Output* out_cc, Env* env, const DataPtr& data, string pattern);
 
-	void DoGenParseCode(Output* out, Env* env, const DataPtr& data, int flags);
+	void DoGenParseCode(Output* out, Env* env, const DataPtr& data, int flags) override;
 
 	void GenCheckingCStr(Output* out, Env* env, const DataPtr& data, const string& str_size);
 
-	void GenDynamicSize(Output* out, Env* env, const DataPtr& data);
+	void GenDynamicSize(Output* out, Env* env, const DataPtr& data) override;
 	void GenDynamicSizeAnyStr(Output* out_cc, Env* env, const DataPtr& data);
 	void GenDynamicSizeRegEx(Output* out_cc, Env* env, const DataPtr& data);
 
-	Type* DoClone() const;
+	Type* DoClone() const override;
 
 	// TODO: insensitive towards byte order till we support unicode
-	bool ByteOrderSensitive() const { return false; }
+	bool ByteOrderSensitive() const override { return false; }
 
 protected:
-	bool DoTraverse(DataDepVisitor* visitor);
+	bool DoTraverse(DataDepVisitor* visitor) override;
 
 private:
 	const ID* string_length_var() const;

--- a/src/pac_type.cc
+++ b/src/pac_type.cc
@@ -24,23 +24,23 @@ Type::type_map_t Type::type_map_;
 
 Type::Type(TypeType tot) : DataDepElement(DataDepElement::TYPE), tot_(tot)
 	{
-	type_decl_ = 0;
+	type_decl_ = nullptr;
 	type_decl_id_ = current_decl_id;
 	declared_as_type_ = false;
-	env_ = 0;
+	env_ = nullptr;
 	value_var_ = default_value_var;
 	ASSERT(value_var_);
 	value_var_type_ = MEMBER_VAR;
 	anonymous_value_var_ = false;
-	size_var_field_ = 0;
-	size_expr_ = 0;
+	size_var_field_ = nullptr;
+	size_expr_ = nullptr;
 	boundary_checked_ = false;
-	parsing_complete_var_field_ = 0;
-	parsing_state_var_field_ = 0;
-	buffering_state_var_field_ = 0;
-	has_value_field_ = 0;
+	parsing_complete_var_field_ = nullptr;
+	parsing_state_var_field_ = nullptr;
+	buffering_state_var_field_ = nullptr;
+	has_value_field_ = nullptr;
 
-	array_until_input_ = 0;
+	array_until_input_ = nullptr;
 
 	incremental_input_ = false;
 	buffer_input_ = false;
@@ -49,16 +49,16 @@ Type::Type(TypeType tot) : DataDepElement(DataDepElement::TYPE), tot_(tot)
 	fields_ = new FieldList();
 
 	attrs_ = new AttrList();
-	attr_byteorder_expr_ = 0;
+	attr_byteorder_expr_ = nullptr;
 	attr_checks_ = new ExprList();
 	attr_enforces_ = new ExprList();
 	attr_chunked_ = false;
 	attr_exportsourcedata_ = false;
-	attr_if_expr_ = 0;
-	attr_length_expr_ = 0;
-	attr_letfields_ = 0;
-	attr_multiline_end_ = 0;
-	attr_linebreaker_ = 0;
+	attr_if_expr_ = nullptr;
+	attr_length_expr_ = nullptr;
+	attr_letfields_ = nullptr;
+	attr_multiline_end_ = nullptr;
+	attr_linebreaker_ = nullptr;
 	attr_oneline_ = false;
 	attr_refcount_ = false;
 	attr_requires_ = new ExprList();
@@ -139,7 +139,7 @@ void Type::set_value_var(const ID* arg_id, int arg_id_type)
 
 const ID* Type::size_var() const
 	{
-	return size_var_field_ ? size_var_field_->id() : 0;
+	return size_var_field_ ? size_var_field_->id() : nullptr;
 	}
 
 void Type::AddField(Field* f)
@@ -570,7 +570,7 @@ void Type::GenParseBuffer(Output* out_cc, Env* env, int flags)
 		data_begin = begin_of_data;
 		}
 	else
-		data_begin = 0;
+		data_begin = nullptr;
 
 	if ( array_until_input_ )
 		{
@@ -763,7 +763,7 @@ Type* Type::MemberDataType(const ID* member_id) const
 
 Type* Type::ElementDataType() const
 	{
-	return 0;
+	return nullptr;
 	}
 
 // Returns false if it is not necessary to add size_var
@@ -969,7 +969,7 @@ bool Type::Bufferable() const
 bool Type::BufferableWithLineBreaker() const
 	{
 	// If the input is an ASCII line with a given linebreaker;
-	return attr_linebreaker_ != 0;
+	return attr_linebreaker_ != nullptr;
 	}
 
 Expr* Type::LineBreaker() const
@@ -993,7 +993,7 @@ const ID* Type::parsing_complete_var() const
 	if ( parsing_complete_var_field_ )
 		return parsing_complete_var_field_->id();
 	else
-		return 0;
+		return nullptr;
 	}
 
 string Type::parsing_complete(Env* env) const
@@ -1007,7 +1007,7 @@ const ID* Type::has_value_var() const
 	if ( has_value_field_ )
 		return has_value_field_->id();
 	else
-		return 0;
+		return nullptr;
 	}
 
 int Type::InitialBufferLength() const
@@ -1096,7 +1096,7 @@ Type* Type::LookUpByID(ID* id)
 			}
 		}
 
-	return new ParameterizedType(id, 0);
+	return new ParameterizedType(id, nullptr);
 	}
 
 void Type::AddPredefinedType(const string& type_name, Type* type)

--- a/src/pac_type.h
+++ b/src/pac_type.h
@@ -26,7 +26,7 @@ public:
 		};
 
 	explicit Type(TypeType tot);
-	virtual ~Type();
+	~Type() override;
 
 	Type* Clone() const;
 
@@ -236,7 +236,7 @@ protected:
 	// Generate code for computing the dynamic size of the type
 	virtual void GenDynamicSize(Output* out, Env* env, const DataPtr& data) = 0;
 
-	bool DoTraverse(DataDepVisitor* visitor);
+	bool DoTraverse(DataDepVisitor* visitor) override;
 
 	virtual Type* DoClone() const = 0;
 

--- a/src/pac_typedecl.cc
+++ b/src/pac_typedecl.cc
@@ -19,7 +19,7 @@
 TypeDecl::TypeDecl(ID* id, ParamList* params, Type* type)
 	: Decl(id, TYPE), params_(params), type_(type)
 	{
-	env_ = 0;
+	env_ = nullptr;
 	type_->set_type_decl(this, true);
 	}
 
@@ -222,8 +222,8 @@ void TypeDecl::GenDestructorFunc(Output* out_h, Output* out_cc)
 
 string TypeDecl::ParseFuncPrototype(Env* env)
 	{
-	const char* func_name = 0;
-	const char* return_type = 0;
+	const char* func_name = nullptr;
+	const char* return_type = nullptr;
 	string params;
 
 	if ( type_->incremental_input() )
@@ -268,7 +268,7 @@ void TypeDecl::GenParsingEnd(Output* out_cc, Env* env, const DataPtr& data)
 		}
 	else
 		{
-		ret_val_0 = type_->DataSize(0, env, data).c_str();
+		ret_val_0 = type_->DataSize(nullptr, env, data).c_str();
 		ret_val_1 = "@@@";
 
 		out_cc->println("BINPAC_ASSERT(%s + (%s) <= %s);", env->RValue(begin_of_data),
@@ -347,7 +347,7 @@ void TypeDecl::GenParseFunc(Output* out_h, Output* out_cc)
 	out_cc->inc_indent();
 	out_cc->println("{");
 
-	DataPtr data(env, 0, 0);
+	DataPtr data(env, nullptr, 0);
 
 	if ( ! type_->incremental_input() )
 		data = DataPtr(env, begin_of_data, 0);
@@ -378,7 +378,7 @@ Type* TypeDecl::LookUpType(const ID* id)
 	{
 	Decl* decl = LookUpDecl(id);
 	if ( ! decl )
-		return 0;
+		return nullptr;
 	switch ( decl->decl_type() )
 		{
 		case TYPE:
@@ -388,6 +388,6 @@ Type* TypeDecl::LookUpType(const ID* id)
 		case ENUM:
 			return static_cast<EnumDecl*>(decl)->DataType();
 		default:
-			return 0;
+			return nullptr;
 		}
 	}

--- a/src/pac_typedecl.cc
+++ b/src/pac_typedecl.cc
@@ -121,7 +121,7 @@ void TypeDecl::GenCode(Output* out_h, Output* out_cc)
 
 	// The first line of class definition
 	out_h->println("");
-	out_h->print("class %s", class_name().c_str());
+	out_h->print("class %s final", class_name().c_str());
 	bool first = true;
 	vector<string>::iterator i;
 	for ( i = base_classes.begin(); i != base_classes.end(); ++i )
@@ -334,8 +334,8 @@ void TypeDecl::GenParseFunc(Output* out_h, Output* out_cc)
 		out_h->println("// 2. If the input is not complete but the type supports");
 		out_h->println("//    incremental input, returns number of input bytes + 1");
 		out_h->println("//    (%s - %s + 1).",
-			env->LValue(end_of_data), 
-			env->LValue(begin_of_data)); 
+			env->LValue(end_of_data),
+			env->LValue(begin_of_data));
 		out_h->println("// 3. An exception will be thrown on error.");
 		}
 #endif

--- a/src/pac_typedecl.h
+++ b/src/pac_typedecl.h
@@ -7,12 +7,12 @@ class TypeDecl : public Decl
 	{
 public:
 	TypeDecl(ID* arg_id, ParamList* arg_params, Type* arg_type);
-	~TypeDecl();
-	void Prepare();
-	void GenForwardDeclaration(Output* out_h);
-	void GenCode(Output* out_h, Output* out_cc);
+	~TypeDecl() override;
+	void Prepare() override;
+	void GenForwardDeclaration(Output* out_h) override;
+	void GenCode(Output* out_h, Output* out_cc) override;
 
-	Env* env() const { return env_; }
+	Env* env() const override { return env_; }
 	Type* type() const { return type_; }
 	string class_name() const;
 	static Type* LookUpType(const ID* id);
@@ -20,7 +20,7 @@ public:
 protected:
 	void AddParam(Param* param);
 	virtual void AddBaseClass(vector<string>* base_classes) const { }
-	void ProcessAttr(Attr* a);
+	void ProcessAttr(Attr* a) override;
 
 	virtual void GenPubDecls(Output* out_h, Output* out_cc);
 	virtual void GenPrivDecls(Output* out_h, Output* out_cc);

--- a/src/pac_varfield.h
+++ b/src/pac_varfield.h
@@ -12,7 +12,7 @@ public:
 	            type)
 		{
 		}
-	void GenPubDecls(Output* out, Env* env)
+	void GenPubDecls(Output* out, Env* env) override
 		{ /* do nothing */
 		}
 	};
@@ -25,7 +25,7 @@ public:
 		: Field(PUB_VAR_FIELD, TYPE_NOT_TO_BE_PARSED | CLASS_MEMBER | PUBLIC_READABLE, id, type)
 		{
 		}
-	~PubVarField() { }
+	~PubVarField() override { }
 	};
 
 // A private variable
@@ -37,9 +37,9 @@ public:
 	            type)
 		{
 		}
-	~PrivVarField() { }
+	~PrivVarField() override { }
 
-	void GenPubDecls(Output* out, Env* env)
+	void GenPubDecls(Output* out, Env* env) override
 		{ /* do nothing */
 		}
 	};
@@ -51,7 +51,7 @@ public:
 		: Field(TEMP_VAR_FIELD, TYPE_NOT_TO_BE_PARSED | NOT_CLASS_MEMBER, id, type)
 		{
 		}
-	~TempVarField() { }
+	~TempVarField() override { }
 	};
 
 #endif // pac_varfield_h

--- a/src/pac_withinput.h
+++ b/src/pac_withinput.h
@@ -9,11 +9,11 @@ class WithInputField : public Field, public Evaluatable
 	{
 public:
 	WithInputField(ID* id, Type* type, InputBuffer* input);
-	virtual ~WithInputField();
+	~WithInputField() override;
 
 	InputBuffer* input() const { return input_; }
 
-	void Prepare(Env* env);
+	void Prepare(Env* env) override;
 
 	// void GenPubDecls(Output* out, Env* env);
 	// void GenPrivDecls(Output* out, Env* env);
@@ -24,12 +24,12 @@ public:
 	void GenParseCode(Output* out, Env* env);
 
 	// Instantiate the Evaluatable interface
-	void GenEval(Output* out, Env* env);
+	void GenEval(Output* out, Env* env) override;
 
-	bool RequiresAnalyzerContext() const;
+	bool RequiresAnalyzerContext() const override;
 
 protected:
-	bool DoTraverse(DataDepVisitor* visitor);
+	bool DoTraverse(DataDepVisitor* visitor) override;
 
 protected:
 	InputBuffer* input_;


### PR DESCRIPTION
This is the first cut of some changes that I'd like to make to both the internal binpac code and the generated output, but I want to get this in before 5.2 branches. This PR adds the following:

- A Cirrus CI configuration for automated builds, which the binpac repo was completely lacking
- A clang-tidy configuration for driving more modernization efforts
- Switches all of the internal binpac code to use `nullptr` instead of `NULL` and `0` for initializing/checking pointer values.
- Changes to generated code:
    - Use `nullptr` for initializing pointers
    - Add `final` keyword to class definitions.
