### PR TITLE
MSVC compiler warning fixes

### DIFF
--- a/src/pac_main.cc
+++ b/src/pac_main.cc
@@ -219,9 +219,9 @@ void usage()
 // FreeBSD doesn't support LeakSanitizer
 #if defined(USING_ASAN) && ! defined(__FreeBSD__)
 #include <sanitizer/lsan_interface.h>
-#define BINPAC_LSAN_DISABLE(x) __lsan_disable(x)
+#define BINPAC_LSAN_DISABLE() __lsan_disable()
 #else
-#define BINPAC_LSAN_DISABLE(x)
+#define BINPAC_LSAN_DISABLE()
 #endif
 
 int main(int argc, char* argv[])

--- a/src/pac_scan.ll
+++ b/src/pac_scan.ll
@@ -1,3 +1,11 @@
+%top{
+// Include stdint.h at the start of the generated file. Typically
+// MSVC will include this header later, after the definitions of
+// the integral type macros. MSVC then complains that about the
+// redefinition of the types. Including stdint.h early avoids this.
+#include <stdint.h>
+}
+
 %{
 #include "pac_action.h"
 #include "pac_array.h"


### PR DESCRIPTION
This first commit fixes the following warning:

```
  [193/1356] Building CXX object auxil\binpac\src\CMakeFiles\binpac.dir\pac_main.cc.obj
D:\repos\zeek\auxil\binpac\src\pac_main.cc(232): warning C4003: not enough arguments for function-like macro invocation 'BINPAC_LSAN_DISABLE'
```

The second commit fixes this block of warnings:

```
c:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\include\stdint.h(49): warning C4005: 'INT8_MIN': macro redefinition
auxil\binpac\pac_scan.cc(59): note: see previous definition of 'INT8_MIN'
c:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\include\stdint.h(50): warning C4005: 'INT16_MIN': macro redefinition
auxil\binpac\pac_scan.cc(62): note: see previous definition of 'INT16_MIN'
c:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\include\stdint.h(51): warning C4005: 'INT32_MIN': macro redefinition
auxil\binpac\pac_scan.cc(65): note: see previous definition of 'INT32_MIN'
c:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\include\stdint.h(53): warning C4005: 'INT8_MAX': macro redefinition
auxil\binpac\pac_scan.cc(68): note: see previous definition of 'INT8_MAX'
c:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\include\stdint.h(54): warning C4005: 'INT16_MAX': macro redefinition
auxil\binpac\pac_scan.cc(71): note: see previous definition of 'INT16_MAX'
c:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\include\stdint.h(55): warning C4005: 'INT32_MAX': macro redefinition
auxil\binpac\pac_scan.cc(74): note: see previous definition of 'INT32_MAX'
c:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\include\stdint.h(57): warning C4005: 'UINT8_MAX': macro redefinition
auxil\binpac\pac_scan.cc(77): note: see previous definition of 'UINT8_MAX'
c:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\include\stdint.h(58): warning C4005: 'UINT16_MAX': macro redefinition
auxil\binpac\pac_scan.cc(80): note: see previous definition of 'UINT16_MAX'
c:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.29.30133\include\stdint.h(59): warning C4005: 'UINT32_MAX': macro redefinition
auxil\binpac\pac_scan.cc(83): note: see previous definition of 'UINT32_MAX'
```