### PR TITLE
CMake updates for binpac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15.0 FATAL_ERROR)
 project(BinPAC C CXX)
 include(cmake/CommonCMakeConfig.cmake)
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -27,7 +27,9 @@ set(binpac_lib_SRCS
 
 if ( ENABLE_SHARED )
   add_library(binpac_lib SHARED ${binpac_lib_SRCS})
+  target_compile_features(binpac_lib PRIVATE cxx_std_17)
   set_target_properties(binpac_lib PROPERTIES
+                        CXX_EXTENSIONS OFF
                         SOVERSION ${BINPAC_SOVERSION}
                         VERSION ${BINPAC_VERSION_MAJOR}.${BINPAC_VERSION_MINOR}
                         MACOSX_RPATH true
@@ -37,7 +39,10 @@ endif ()
 
 if ( ENABLE_STATIC )
   add_library(binpac_static STATIC ${binpac_lib_SRCS})
-  set_target_properties(binpac_static PROPERTIES OUTPUT_NAME binpac)
+  target_compile_features(binpac_static PRIVATE cxx_std_17)
+  set_target_properties(binpac_static PROPERTIES
+                        CXX_EXTENSIONS OFF
+                        OUTPUT_NAME binpac)
   install(TARGETS binpac_static DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif ()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,6 @@ if (MSVC)
 else()
     set_property(SOURCE pac_scan.cc APPEND_STRING PROPERTY COMPILE_FLAGS "-Wno-sign-compare")
 endif()
-include(RequireCXX17)
 
 include_directories(${PROJECT_SOURCE_DIR}/src
                     ${PROJECT_BINARY_DIR}/src)
@@ -103,6 +102,8 @@ set(binpac_SRCS
 )
 
 add_executable(binpac ${binpac_SRCS})
+target_compile_features(binpac PRIVATE cxx_std_17)
+set_target_properties(binpac PROPERTIES CXX_EXTENSIONS OFF)
 
 if ( MSVC )
     # If building separately from zeek, we need to add the libunistd subdirectory so


### PR DESCRIPTION
This is similar to https://github.com/zeek/zeek/pull/3124, adjusting the CMake scripts to always use `-std=c++17` for consistency across all of the projects. This also updates the minimum CMake version requirement to 3.15.0 to match Zeek.

This shouldn't go into master until after Zeek 6.0 is out to avoid branch management issues with that release.