### PR TITLE
Format output closer to what clang-format would output

### DIFF
--- a/src/pac_action.cc
+++ b/src/pac_action.cc
@@ -34,15 +34,14 @@ void AnalyzerAction::GenCode(Output* out_h, Output* out_cc, AnalyzerDecl* decl) 
 
     out_h->println("void %s;", action_func_proto.c_str());
 
-    out_cc->println("void %s::%s", decl->class_name().c_str(), action_func_proto.c_str());
+    out_cc->println("void %s::%s {", decl->class_name().c_str(), action_func_proto.c_str());
     out_cc->inc_indent();
-    out_cc->println("{");
 
     code_->GenCode(out_cc, &action_func_env);
 
     out_cc->println("");
-    out_cc->println("}");
     out_cc->dec_indent();
+    out_cc->println("}");
     out_cc->println("");
 }
 

--- a/src/pac_btype.cc
+++ b/src/pac_btype.cc
@@ -94,7 +94,7 @@ void BuiltInType::DoGenParseCode(Output* out_cc, Env* env, const DataPtr& data, 
 
         case INT8:
         case UINT8:
-            out_cc->println("%s = *((%s const *) (%s));", lvalue(), DataTypeStr().c_str(), data.ptr_expr());
+            out_cc->println("%s = *((%s const*)(%s));", lvalue(), DataTypeStr().c_str(), data.ptr_expr());
             break;
         case INT16:
         case UINT16:
@@ -104,13 +104,13 @@ void BuiltInType::DoGenParseCode(Output* out_cc, Env* env, const DataPtr& data, 
         case UINT64:
 #if 0
 			out_cc->println("%s = UnMarshall<%s>(%s, %s);",
-				lvalue(), 
-				DataTypeStr().c_str(), 
+				lvalue(),
+				DataTypeStr().c_str(),
 				data.ptr_expr(),
 				EvalByteOrder(out_cc, env).c_str());
 #else
-            out_cc->println("%s = FixByteOrder(%s, *((%s const *) (%s)));", lvalue(),
-                            EvalByteOrder(out_cc, env).c_str(), DataTypeStr().c_str(), data.ptr_expr());
+            out_cc->println("%s = FixByteOrder(%s, *((%s const*)(%s)));", lvalue(), EvalByteOrder(out_cc, env).c_str(),
+                            DataTypeStr().c_str(), data.ptr_expr());
 #endif
             break;
     }

--- a/src/pac_conn.cc
+++ b/src/pac_conn.cc
@@ -63,9 +63,8 @@ void ConnDecl::GenEOFFunc(Output* out_h, Output* out_cc) {
 
     out_h->println("void %s;", proto.c_str());
 
-    out_cc->println("void %s::%s", class_name().c_str(), proto.c_str());
+    out_cc->println("void %s::%s {", class_name().c_str(), proto.c_str());
     out_cc->inc_indent();
-    out_cc->println("{");
 
     out_cc->println("if ( is_orig )");
     out_cc->inc_indent();
@@ -81,8 +80,8 @@ void ConnDecl::GenEOFFunc(Output* out_h, Output* out_cc) {
 
     out_cc->dec_indent();
 
-    out_cc->println("}");
     out_cc->dec_indent();
+    out_cc->println("}");
     out_cc->println("");
 }
 
@@ -91,9 +90,8 @@ void ConnDecl::GenGapFunc(Output* out_h, Output* out_cc) {
 
     out_h->println("void %s;", proto.c_str());
 
-    out_cc->println("void %s::%s", class_name().c_str(), proto.c_str());
+    out_cc->println("void %s::%s {", class_name().c_str(), proto.c_str());
     out_cc->inc_indent();
-    out_cc->println("{");
 
     out_cc->println("if ( is_orig )");
     out_cc->inc_indent();
@@ -104,8 +102,8 @@ void ConnDecl::GenGapFunc(Output* out_h, Output* out_cc) {
     out_cc->println("%s->%s(gap_length);", env_->LValue(downflow_id), kFlowGap);
     out_cc->dec_indent();
 
-    out_cc->println("}");
     out_cc->dec_indent();
+    out_cc->println("}");
     out_cc->println("");
 }
 
@@ -114,9 +112,8 @@ void ConnDecl::GenProcessFunc(Output* out_h, Output* out_cc) {
 
     out_h->println("void %s;", proto.c_str());
 
-    out_cc->println("void %s::%s", class_name().c_str(), proto.c_str());
+    out_cc->println("void %s::%s {", class_name().c_str(), proto.c_str());
     out_cc->inc_indent();
-    out_cc->println("{");
 
     out_cc->println("if ( is_orig )");
     out_cc->inc_indent();
@@ -127,7 +124,7 @@ void ConnDecl::GenProcessFunc(Output* out_h, Output* out_cc) {
     out_cc->println("%s->%s(begin, end);", env_->LValue(downflow_id), kNewData);
     out_cc->dec_indent();
 
-    out_cc->println("}");
     out_cc->dec_indent();
+    out_cc->println("}");
     out_cc->println("");
 }

--- a/src/pac_ctype.cc
+++ b/src/pac_ctype.cc
@@ -3,11 +3,11 @@
 string CType::DeclareInstance(const string& var) const { return strfmt("%s %s", name().c_str(), var.c_str()); }
 
 string CType::DeclareConstReference(const string& var) const {
-    return strfmt("%s const &%s", name().c_str(), var.c_str());
+    return strfmt("%s const& %s", name().c_str(), var.c_str());
 }
 
 string CType::DeclareConstPointer(const string& var) const {
-    return strfmt("%s const *%s", name().c_str(), var.c_str());
+    return strfmt("%s const* %s", name().c_str(), var.c_str());
 }
 
-string CType::DeclarePointer(const string& var) const { return strfmt("%s *%s", name().c_str(), var.c_str()); }
+string CType::DeclarePointer(const string& var) const { return strfmt("%s* %s", name().c_str(), var.c_str()); }

--- a/src/pac_dataptr.cc
+++ b/src/pac_dataptr.cc
@@ -32,11 +32,10 @@ void DataPtr::GenBoundaryCheck(Output* out_cc, Env* env, const char* data_size, 
     ASSERT(id_);
 
     out_cc->println("// Checking out-of-bound for \"%s\"", data_name);
-    out_cc->println("if ( %s + (%s) > %s || %s + (%s) < %s )", ptr_expr(), data_size, env->RValue(end_of_data),
+    out_cc->println("if ( %s + (%s) > %s || %s + (%s) < %s ) {", ptr_expr(), data_size, env->RValue(end_of_data),
                     ptr_expr(), data_size, ptr_expr());
 
     out_cc->inc_indent();
-    out_cc->println("{");
 
     char* data_offset = AbsOffsetExpr(env, begin_of_data);
 
@@ -47,6 +46,6 @@ void DataPtr::GenBoundaryCheck(Output* out_cc, Env* env, const char* data_size, 
 
     delete[] data_offset;
 
-    out_cc->println("}");
     out_cc->dec_indent();
+    out_cc->println("}");
 }

--- a/src/pac_expr.cc
+++ b/src/pac_expr.cc
@@ -209,11 +209,10 @@ void Expr::GenCaseEval(Output* out_cc, Env* env) {
     foreach (i, CaseExprList, cases_)
         (*i)->value()->ForceIDEval(out_cc, env);
 
-    out_cc->println("switch ( %s )", operand_[0]->EvalExpr(out_cc, env));
+    out_cc->println("switch ( %s ) {", operand_[0]->EvalExpr(out_cc, env));
     Type* switch_type = operand_[0]->DataType(env);
 
     out_cc->inc_indent();
-    out_cc->println("{");
 
     CaseExpr* default_case = nullptr;
     foreach (i, CaseExprList, cases_) {
@@ -246,8 +245,8 @@ void Expr::GenCaseEval(Output* out_cc, Env* env) {
     out_cc->println("break;");
     out_cc->dec_indent();
 
-    out_cc->println("}");
     out_cc->dec_indent();
+    out_cc->println("}");
 
     env->SetEvaluated(val_var);
     str_ = env->RValue(val_var);

--- a/src/pac_func.cc
+++ b/src/pac_func.cc
@@ -51,27 +51,23 @@ void Function::GenCode(Output* out_h, Output* out_cc) {
     ASSERT(! (expr_ && code_));
 
     if ( expr_ ) {
-        out_cc->println("%s", proto_str.c_str());
-
+        out_cc->println("%s {", proto_str.c_str());
         out_cc->inc_indent();
-        out_cc->println("{");
 
         out_cc->println("return static_cast<%s>(%s);", type_->DataTypeStr().c_str(), expr_->EvalExpr(out_cc, env_));
 
-        out_cc->println("}");
         out_cc->dec_indent();
+        out_cc->println("}");
     }
 
     else if ( code_ ) {
-        out_cc->println("%s", proto_str.c_str());
-
+        out_cc->println("%s {", proto_str.c_str());
         out_cc->inc_indent();
-        out_cc->println("{");
 
         code_->GenCode(out_cc, env_);
 
-        out_cc->println("}");
         out_cc->dec_indent();
+        out_cc->println("}");
     }
 
     out_cc->println("");

--- a/src/pac_let.cc
+++ b/src/pac_let.cc
@@ -63,9 +63,8 @@ void LetField::GenParseCode(Output* out_cc, Env* env) {
         // force evaluation of IDs contained in this expr
         expr()->ForceIDEval(out_cc, env);
 
-        out_cc->println("if ( %s )", env->RValue(type_->has_value_var()));
+        out_cc->println("if ( %s ) {", env->RValue(type_->has_value_var()));
         out_cc->inc_indent();
-        out_cc->println("{");
     }
 
     out_cc->println("%s = %s;", env->LValue(id_), expr()->EvalExpr(out_cc, env));
@@ -73,8 +72,8 @@ void LetField::GenParseCode(Output* out_cc, Env* env) {
         env->SetEvaluated(id_);
 
     if ( type_->attr_if_expr() ) {
-        out_cc->println("}");
         out_cc->dec_indent();
+        out_cc->println("}");
     }
 }
 

--- a/src/pac_output.cc
+++ b/src/pac_output.cc
@@ -49,8 +49,13 @@ int Output::print(const char* fmt, ...) {
 }
 
 int Output::println(const char* fmt, ...) {
+    if ( strlen(fmt) == 0 ) {
+        fprintf(fp, "\n");
+        return 0;
+    }
+
     for ( int i = 0; i < indent(); ++i )
-        fprintf(fp, "\t");
+        fprintf(fp, "    ");
 
     va_list ap;
     va_start(ap, fmt);

--- a/src/pac_paramtype.cc
+++ b/src/pac_paramtype.cc
@@ -27,7 +27,7 @@ void ParameterizedType::AddParamArg(Expr* arg) { args_->push_back(arg); }
 
 bool ParameterizedType::DefineValueVar() const { return true; }
 
-string ParameterizedType::DataTypeStr() const { return strfmt("%s *", type_id_->Name()); }
+string ParameterizedType::DataTypeStr() const { return strfmt("%s*", type_id_->Name()); }
 
 Type* ParameterizedType::MemberDataType(const ID* member_id) const {
     Type* ref_type = TypeDecl::LookUpType(type_id_);

--- a/src/pac_strtype.cc
+++ b/src/pac_strtype.cc
@@ -233,12 +233,11 @@ void StringType::GenCheckingCStr(Output* out_cc, Env* env, const DataPtr& data, 
     string str_val = str_->str();
 
     // Compare the string and report error on mismatch
-    out_cc->println("if ( memcmp(%s, %s, %s) != 0 )", data.ptr_expr(), str_val.c_str(), str_size.c_str());
+    out_cc->println("if ( memcmp(%s, %s, %s) != 0 ) {", data.ptr_expr(), str_val.c_str(), str_size.c_str());
     out_cc->inc_indent();
-    out_cc->println("{");
     GenStringMismatch(out_cc, env, data, str_val);
-    out_cc->println("}");
     out_cc->dec_indent();
+    out_cc->println("}");
 }
 
 void StringType::GenDynamicSizeRegEx(Output* out_cc, Env* env, const DataPtr& data) {
@@ -261,13 +260,12 @@ void StringType::GenDynamicSizeRegEx(Output* out_cc, Env* env, const DataPtr& da
 
     env->SetEvaluated(string_length_var());
 
-    out_cc->println("if ( %s < 0 )", env->RValue(string_length_var()));
+    out_cc->println("if ( %s < 0 ) {", env->RValue(string_length_var()));
     out_cc->inc_indent();
-    out_cc->println("{");
     string tmp = strfmt("\"%s\"", regex_->str().c_str());
     GenStringMismatch(out_cc, env, data, tmp);
-    out_cc->println("}");
     out_cc->dec_indent();
+    out_cc->println("}");
 }
 
 void StringType::GenDynamicSizeAnyStr(Output* out_cc, Env* env, const DataPtr& data) {

--- a/src/pac_type.h
+++ b/src/pac_type.h
@@ -111,7 +111,7 @@ public:
     string DataTypeConstRefStr() const {
         string data_type = DataTypeStr();
         if ( ! IsPointerType() && ! IsNumericType() )
-            data_type += " const &";
+            data_type += " const&";
         return data_type;
     }
 

--- a/src/pac_typedecl.cc
+++ b/src/pac_typedecl.cc
@@ -114,10 +114,9 @@ void TypeDecl::GenCode(Output* out_h, Output* out_cc) {
         else
             out_h->print(", public %s", i->c_str());
     }
-    out_h->print("\n");
+    out_h->println(" {");
 
     // Public members
-    out_h->println("{");
     out_h->println("public:");
     out_h->inc_indent();
 
@@ -166,18 +165,16 @@ void TypeDecl::GenConstructorFunc(Output* out_h, Output* out_cc) {
 
     out_h->println("%s;", proto.c_str());
 
-    out_cc->println("%s::%s", class_name().c_str(), proto.c_str());
+    out_cc->println("%s::%s {", class_name().c_str(), proto.c_str());
     out_cc->inc_indent();
-
-    out_cc->println("{");
 
     // GenParamAssignments(params_, out_cc, env_);
 
     type_->GenInitCode(out_cc, env_);
     GenInitCode(out_cc);
 
-    out_cc->println("}\n");
     out_cc->dec_indent();
+    out_cc->println("}\n");
 }
 
 void TypeDecl::GenDestructorFunc(Output* out_h, Output* out_cc) {
@@ -185,15 +182,14 @@ void TypeDecl::GenDestructorFunc(Output* out_h, Output* out_cc) {
 
     out_h->println("%s;", proto.c_str());
 
-    out_cc->println("%s::%s", class_name().c_str(), proto.c_str());
+    out_cc->println("%s::%s {", class_name().c_str(), proto.c_str());
     out_cc->inc_indent();
-    out_cc->println("{");
 
     GenCleanUpCode(out_cc);
     type_->GenCleanUpCode(out_cc, env_);
 
-    out_cc->println("}\n");
     out_cc->dec_indent();
+    out_cc->println("}\n");
 }
 
 string TypeDecl::ParseFuncPrototype(Env* env) {
@@ -283,8 +279,7 @@ void TypeDecl::GenParseFunc(Output* out_h, Output* out_cc) {
         env->SetEvaluated(end_of_data);
     }
 
-    string proto;
-    proto = ParseFuncPrototype(env);
+    string proto = ParseFuncPrototype(env);
 
 #if 0
 	if ( func_type == PARSE )
@@ -303,9 +298,8 @@ void TypeDecl::GenParseFunc(Output* out_h, Output* out_cc) {
     out_h->println(proto.c_str(), "", ";");
 
     string tmp = strfmt("%s::", class_name().c_str());
-    out_cc->println(proto.c_str(), tmp.c_str(), "");
+    out_cc->println(proto.c_str(), tmp.c_str(), " {");
     out_cc->inc_indent();
-    out_cc->println("{");
 
     DataPtr data(env, nullptr, 0);
 
@@ -314,8 +308,8 @@ void TypeDecl::GenParseFunc(Output* out_h, Output* out_cc) {
     type_->GenParseCode(out_cc, env, data, 0);
     GenParsingEnd(out_cc, env, data);
 
-    out_cc->println("}\n");
     out_cc->dec_indent();
+    out_cc->println("}\n");
 }
 
 void TypeDecl::GenInitialBufferLengthFunc(Output* out_h, Output* out_cc) {

--- a/src/pac_withinput.cc
+++ b/src/pac_withinput.cc
@@ -39,9 +39,8 @@ void WithInputField::GenParseCode(Output* out_cc, Env* env) {
     if ( type_->attr_if_expr() ) {
         // A conditional field
         env->Evaluate(out_cc, type_->has_value_var());
-        out_cc->println("if ( %s )", env->RValue(type_->has_value_var()));
+        out_cc->println("if ( %s ) {", env->RValue(type_->has_value_var()));
         out_cc->inc_indent();
-        out_cc->println("{");
     }
     else
         out_cc->println("{");
@@ -52,8 +51,8 @@ void WithInputField::GenParseCode(Output* out_cc, Env* env) {
     type_->GenParseCode(out_cc, &field_env, input()->GenDataBeginEnd(out_cc, &field_env), 0);
 
     if ( type_->attr_if_expr() ) {
-        out_cc->println("}");
         out_cc->dec_indent();
+        out_cc->println("}");
     }
     else
         out_cc->println("}");


### PR DESCRIPTION
While working directly on a pac.cc file generated from a large analyzer, my Emacs session reformatted the whole file based on the clang-format configuration used by all of the Zeek projects. This took a very long time, since the change set was pretty large. This PR changes the output from binpac to be much closer to what clang-format would output. It's not perfect, since clang-format will do things like compressing empty blocks or splitting long lines, and we can't do that easily in binpac.