### PR TITLE
Clang-Tidy fixes for findings reported by Zeek in generated code

### DIFF
--- a/.cmake-format.json
+++ b/.cmake-format.json
@@ -1,0 +1,101 @@
+{
+  "parse": {
+    "additional_commands": {
+      "CheckIPProto": {
+        "kwargs": {
+          "_proto": "*"
+        }
+      },
+      "CheckType": {
+        "kwargs": {
+          "_type": "*",
+          "_alt_type": "*",
+          "_var": "*"
+        }
+      },
+      "SetPackageVersion": {
+        "kwargs": {
+          "_version": "*"
+        }
+      },
+      "SetPackageFileName": {
+        "kwargs": {
+          "_version": "*"
+        }
+      },
+      "SetPackageInstallScripts": {
+        "kwargs": {
+          "VERSION": "*"
+        }
+      },
+      "ConfigurePackaging": {
+        "kwargs": {
+          "_version": "*"
+        }
+      },
+      "SetPackageGenerators": {},
+      "SetPackageMetadata": {},
+      "FindRequiredPackage": {
+        "kwargs": {
+          "packageName": "*"
+        }
+      },
+      "InstallClobberImmune": {
+        "kwargs": {
+          "_srcfile": "*",
+          "_dstfile": "*"
+        }
+      },
+      "InstallPackageConfigFile": {
+        "kwargs": {
+          "_srcfile": "*",
+          "_dstdir": "*",
+          "_dstfilename": "*"
+        }
+      },
+      "InstallShellScript": {
+        "kwargs": {
+          "_srcfile": "*",
+          "_dstfile": "*"
+        }
+      },
+      "InstallSymLink": {
+        "kwargs": {
+          "_filepath": "*",
+          "_sympath": "*"
+        }
+      },
+      "spicy_add_analyzer": {
+        "kwargs": {
+          "NAME": "*",
+          "PACKAGE_NAME": "*",
+          "SOURCES": "*",
+          "MODULES": "*"
+        }
+      },
+      "zeek_add_plugin": {
+        "kwargs": {
+          "INCLUDE_DIRS": "*",
+          "DEPENDENCIES": "*",
+          "SOURCES": "*",
+          "BIFS": "*",
+          "PAC": "*"
+        }
+      }
+    }
+  },
+  "format": {
+    "always_wrap": [
+      "spicy_add_analyzer",
+      "zeek_add_plugin"
+    ],
+    "line_width": 100,
+    "tab_size": 4,
+    "separate_ctrl_name_with_space": true,
+    "max_subgroups_hwrap": 3,
+    "line_ending": "unix"
+  },
+  "markup": {
+    "enable_markup": false
+  }
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,11 +17,6 @@ repos:
     - id: shfmt
       args: ["-w", "-i", "4", "-ci"]
 
-- repo: https://github.com/google/yapf
-  rev: v0.40.2
-  hooks:
-  - id: yapf
-
 - repo: https://github.com/cheshirekow/cmake-format-precommit
   rev: v0.6.13
   hooks:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,10 +14,10 @@ set(BINPAC_SOVERSION 0)
 
 set(ENABLE_SHARED true)
 
-if(ENABLE_STATIC_ONLY)
-  set(ENABLE_STATIC true)
-  set(ENABLE_SHARED false)
-endif()
+if (ENABLE_STATIC_ONLY)
+    set(ENABLE_STATIC true)
+    set(ENABLE_SHARED false)
+endif ()
 
 # Set default install paths
 include(GNUInstallDirs)
@@ -28,9 +28,9 @@ include(GNUInstallDirs)
 find_package(FLEX REQUIRED)
 find_package(BISON REQUIRED)
 
-if(MSVC)
-  add_compile_options(/J) # Similar to -funsigned-char on other platforms
-endif()
+if (MSVC)
+    add_compile_options(/J) # Similar to -funsigned-char on other platforms
+endif ()
 
 # ##############################################################################
 # System Introspection
@@ -48,38 +48,38 @@ add_subdirectory(src)
 # ##############################################################################
 # Build Summary
 
-if(CMAKE_BUILD_TYPE)
-  string(TOUPPER ${CMAKE_BUILD_TYPE} BuildType)
-endif()
+if (CMAKE_BUILD_TYPE)
+    string(TOUPPER ${CMAKE_BUILD_TYPE} BuildType)
+endif ()
 
-macro(display test desc summary)
-  if(${test})
-    set(${summary} ${desc})
-  else()
-    set(${summary} no)
-  endif()
-endmacro()
+macro (display test desc summary)
+    if (${test})
+        set(${summary} ${desc})
+    else ()
+        set(${summary} no)
+    endif ()
+endmacro ()
 
 display(ENABLE_SHARED yes shared_summary)
 display(ENABLE_STATIC yes static_summary)
 
 message(
-  "\n==================|  BinPAC Build Summary  |===================="
-  "\nVersion:           ${BINPAC_VERSION}"
-  "\nSO version:        ${BINPAC_SOVERSION}"
-  "\n"
-  "\nBuild Type:        ${CMAKE_BUILD_TYPE}"
-  "\nDebug mode:        ${ENABLE_DEBUG}"
-  "\nInstall prefix:    ${CMAKE_INSTALL_PREFIX}"
-  "\nShared libs:       ${shared_summary}"
-  "\nStatic libs:       ${static_summary}"
-  "\n"
-  "\nCC:                ${CMAKE_C_COMPILER}"
-  "\nCFLAGS:            ${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_${BuildType}}"
-  "\nCXX:               ${CMAKE_CXX_COMPILER}"
-  "\nCXXFLAGS:          ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${BuildType}}"
-  "\nCPP:               ${CMAKE_CXX_COMPILER}"
-  "\n"
-  "\n================================================================\n")
+    "\n==================|  BinPAC Build Summary  |===================="
+    "\nVersion:           ${BINPAC_VERSION}"
+    "\nSO version:        ${BINPAC_SOVERSION}"
+    "\n"
+    "\nBuild Type:        ${CMAKE_BUILD_TYPE}"
+    "\nDebug mode:        ${ENABLE_DEBUG}"
+    "\nInstall prefix:    ${CMAKE_INSTALL_PREFIX}"
+    "\nShared libs:       ${shared_summary}"
+    "\nStatic libs:       ${static_summary}"
+    "\n"
+    "\nCC:                ${CMAKE_C_COMPILER}"
+    "\nCFLAGS:            ${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_${BuildType}}"
+    "\nCXX:               ${CMAKE_CXX_COMPILER}"
+    "\nCXXFLAGS:          ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${BuildType}}"
+    "\nCPP:               ${CMAKE_CXX_COMPILER}"
+    "\n"
+    "\n================================================================\n")
 
 include(UserChangedWarning)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -4,58 +4,48 @@ test_big_endian(HOST_BIGENDIAN)
 include(CheckTypeSize)
 check_type_size("unsigned int" SIZEOF_UNSIGNED_INT)
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/binpac.h.in
-               ${CMAKE_CURRENT_BINARY_DIR}/binpac.h)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/binpac.h.in ${CMAKE_CURRENT_BINARY_DIR}/binpac.h)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
-set(binpac_headers
-    ${CMAKE_CURRENT_BINARY_DIR}/binpac.h binpac_analyzer.h binpac_buffer.h
-    binpac_bytestring.h binpac_exception.h binpac_regex.h)
+set(binpac_headers ${CMAKE_CURRENT_BINARY_DIR}/binpac.h binpac_analyzer.h binpac_buffer.h
+                   binpac_bytestring.h binpac_exception.h binpac_regex.h)
 
-set(binpac_lib_SRCS binpac_buffer.cc binpac_bytestring.cc binpac_regex.cc
-                    ${binpac_headers})
+set(binpac_lib_SRCS binpac_buffer.cc binpac_bytestring.cc binpac_regex.cc ${binpac_headers})
 
-if(ENABLE_SHARED)
-  add_library(binpac_lib SHARED ${binpac_lib_SRCS})
-  target_compile_features(binpac_lib PRIVATE cxx_std_17)
-  set_target_properties(
-    binpac_lib
-    PROPERTIES CXX_EXTENSIONS OFF
-               SOVERSION ${BINPAC_SOVERSION}
-               VERSION ${BINPAC_VERSION_MAJOR}.${BINPAC_VERSION_MINOR}
-               MACOSX_RPATH true
-               OUTPUT_NAME binpac)
-  install(TARGETS binpac_lib DESTINATION ${CMAKE_INSTALL_LIBDIR})
-endif()
+if (ENABLE_SHARED)
+    add_library(binpac_lib SHARED ${binpac_lib_SRCS})
+    target_compile_features(binpac_lib PRIVATE cxx_std_17)
+    set_target_properties(
+        binpac_lib
+        PROPERTIES CXX_EXTENSIONS OFF
+                   SOVERSION ${BINPAC_SOVERSION}
+                   VERSION ${BINPAC_VERSION_MAJOR}.${BINPAC_VERSION_MINOR}
+                   MACOSX_RPATH true
+                   OUTPUT_NAME binpac)
+    install(TARGETS binpac_lib DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif ()
 
-if(ENABLE_STATIC)
-  add_library(binpac_static STATIC ${binpac_lib_SRCS})
-  target_compile_features(binpac_static PRIVATE cxx_std_17)
-  set_target_properties(binpac_static PROPERTIES CXX_EXTENSIONS OFF OUTPUT_NAME
-                                                                    binpac)
-  install(TARGETS binpac_static DESTINATION ${CMAKE_INSTALL_LIBDIR})
-endif()
+if (ENABLE_STATIC)
+    add_library(binpac_static STATIC ${binpac_lib_SRCS})
+    target_compile_features(binpac_static PRIVATE cxx_std_17)
+    set_target_properties(binpac_static PROPERTIES CXX_EXTENSIONS OFF OUTPUT_NAME binpac)
+    install(TARGETS binpac_static DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif ()
 
-if(ZEEK_ROOT_DIR)
-  # Installed in binpac subdir just for organization purposes.
-  install(FILES ${binpac_headers}
-          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/binpac)
-else()
-  install(FILES ${binpac_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-endif()
+if (ZEEK_ROOT_DIR)
+    # Installed in binpac subdir just for organization purposes.
+    install(FILES ${binpac_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/binpac)
+else ()
+    install(FILES ${binpac_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+endif ()
 
 # This is set to assist superprojects that want to build BinPac from source and
 # rely on it as a target
-if(ENABLE_SHARED)
-  set(BinPAC_LIBRARY
-      binpac_lib
-      CACHE STRING "BinPAC library" FORCE)
-else()
-  set(BinPAC_LIBRARY
-      binpac_static
-      CACHE STRING "BinPAC library" FORCE)
-endif()
+if (ENABLE_SHARED)
+    set(BinPAC_LIBRARY binpac_lib CACHE STRING "BinPAC library" FORCE)
+else ()
+    set(BinPAC_LIBRARY binpac_static CACHE STRING "BinPAC library" FORCE)
+endif ()
 
-set(BinPAC_INCLUDE_DIR
-    ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
+set(BinPAC_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
     CACHE STRING "BinPAC header directories" FORCE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,20 +1,12 @@
-bison_target(
-  PACParser pac_parse.yy ${BinPAC_BINARY_DIR}/src/pac_parse.cc
-  DEFINES_FILE ${BinPAC_BINARY_DIR}/src/pac_parse.h
-  COMPILE_FLAGS "--debug")
+bison_target(PACParser pac_parse.yy ${BinPAC_BINARY_DIR}/src/pac_parse.cc
+             DEFINES_FILE ${BinPAC_BINARY_DIR}/src/pac_parse.h COMPILE_FLAGS "--debug")
 flex_target(PACScanner pac_scan.ll ${BinPAC_BINARY_DIR}/pac_scan.cc)
 add_flex_bison_dependency(PACScanner PACParser)
-if(MSVC)
-  set_property(
-    SOURCE pac_scan.cc
-    APPEND_STRING
-    PROPERTY COMPILE_FLAGS "/wd4018")
-else()
-  set_property(
-    SOURCE pac_scan.cc
-    APPEND_STRING
-    PROPERTY COMPILE_FLAGS "-Wno-sign-compare")
-endif()
+if (MSVC)
+    set_property(SOURCE pac_scan.cc APPEND_STRING PROPERTY COMPILE_FLAGS "/wd4018")
+else ()
+    set_property(SOURCE pac_scan.cc APPEND_STRING PROPERTY COMPILE_FLAGS "-Wno-sign-compare")
+endif ()
 
 include_directories(${PROJECT_SOURCE_DIR}/src ${PROJECT_BINARY_DIR}/src)
 
@@ -110,19 +102,17 @@ add_executable(binpac ${binpac_SRCS})
 target_compile_features(binpac PRIVATE cxx_std_17)
 set_target_properties(binpac PROPERTIES CXX_EXTENSIONS OFF)
 
-if(MSVC)
-  # If building separately from zeek, we need to add the libunistd subdirectory
-  # so that linking doesn't fail.
-  if("${CMAKE_PROJECT_NAME}" STREQUAL "BinPAC")
-    add_subdirectory(auxil/libunistd EXCLUDE_FROM_ALL)
-  endif()
-  target_link_libraries(binpac PRIVATE libunistd)
-endif()
+if (MSVC)
+    # If building separately from zeek, we need to add the libunistd subdirectory
+    # so that linking doesn't fail.
+    if ("${CMAKE_PROJECT_NAME}" STREQUAL "BinPAC")
+        add_subdirectory(auxil/libunistd EXCLUDE_FROM_ALL)
+    endif ()
+    target_link_libraries(binpac PRIVATE libunistd)
+endif ()
 
 install(TARGETS binpac DESTINATION bin)
 
 # This is set to assist superprojects that want to build BinPac from source and
 # rely on it as a target
-set(BinPAC_EXE
-    binpac
-    CACHE STRING "BinPAC executable" FORCE)
+set(BinPAC_EXE binpac CACHE STRING "BinPAC executable" FORCE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,6 +82,7 @@ set(binpac_SRCS
     pac_id.h
     pac_inputbuf.h
     pac_let.h
+    pac_nullptr.h
     pac_number.h
     pac_output.h
     pac_param.h

--- a/src/pac_case.cc
+++ b/src/pac_case.cc
@@ -117,6 +117,7 @@ void CaseType::GenCleanUpCode(Output* out_cc, Env* env) {
     Type::GenCleanUpCode(out_cc, env);
 
     env->set_in_branch(true);
+    out_cc->println("// NOLINTBEGIN(bugprone-branch-clone)");
     out_cc->println("switch ( %s ) {", env->RValue(index_var_));
     out_cc->inc_indent();
     foreach (i, CaseFieldList, cases_) {
@@ -125,6 +126,7 @@ void CaseType::GenCleanUpCode(Output* out_cc, Env* env) {
     }
     out_cc->dec_indent();
     out_cc->println("}");
+    out_cc->println("// NOLINTEND(bugprone-branch-clone)");
     env->set_in_branch(false);
 }
 
@@ -141,6 +143,7 @@ void CaseType::DoGenParseCode(Output* out_cc, Env* env, const DataPtr& data, int
     env->SetEvaluated(index_var_);
 
     env->set_in_branch(true);
+    out_cc->println("// NOLINTBEGIN(bugprone-branch-clone)");
     out_cc->println("switch ( %s ) {", env->RValue(index_var_));
     out_cc->inc_indent();
     bool has_default_case = false;
@@ -161,6 +164,7 @@ void CaseType::DoGenParseCode(Output* out_cc, Env* env, const DataPtr& data, int
     }
     out_cc->dec_indent();
     out_cc->println("}");
+    out_cc->println("// NOLINTEND(bugprone-branch-clone)");
     env->set_in_branch(false);
 
     if ( compute_size_var )
@@ -307,6 +311,7 @@ void CaseField::GenPubDecls(Output* out_h, Env* env) {
     if ( ! index_ )
         out_h->println("return %s;", lvalue());
     else {
+        out_h->println("// NOLINTBEGIN(bugprone-branch-clone)");
         out_h->println("switch ( %s ) {", env->RValue(index_var_));
         out_h->inc_indent();
         GenCaseStr(index_, out_h, env, case_type()->IndexExpr()->DataType(env));
@@ -323,6 +328,7 @@ void CaseField::GenPubDecls(Output* out_h, Env* env) {
 
         out_h->dec_indent();
         out_h->println("}");
+        out_h->println("// NOLINTEND(bugprone-branch-clone)");
 
         out_h->println("return %s;", lvalue());
     }

--- a/src/pac_case.cc
+++ b/src/pac_case.cc
@@ -284,7 +284,10 @@ void GenCaseStr(ExprList* index_list, Output* out_cc, Env* env, Type* switch_typ
             // We're always using "int" for storage, so ok to just
             // cast into the type used by the switch statement since
             // some unsafe stuff is already checked above.
-            out_cc->println("case ((%s)%d):", switch_type->DataTypeStr().c_str(), index_const);
+            if ( ! switch_type->IsBooleanType() )
+                out_cc->println("case ((%s)%d):", switch_type->DataTypeStr().c_str(), index_const);
+            else
+                out_cc->println("case %s:", index_const == 0 ? "false" : "true");
         }
     }
     else {

--- a/src/pac_common.h
+++ b/src/pac_common.h
@@ -65,6 +65,7 @@ class InputBuffer;
 class LetDef;
 class LetField;
 class ID;
+class Nullptr;
 class Number;
 class Output;
 class PacPrimitive;

--- a/src/pac_decl.cc
+++ b/src/pac_decl.cc
@@ -138,8 +138,8 @@ void HelperDecl::GenCode(Output* out_h, Output* out_cc) {
 		Decl *decl = Decl::LookUpDecl(context_id_);
 		if ( ! decl )
 			{
-			throw Exception(context_id_, 
-			                fmt("cannot find declaration for %s", 
+			throw Exception(context_id_,
+			                fmt("cannot find declaration for %s",
 			                    context_id_->Name()));
 			}
 		env = decl->env();

--- a/src/pac_expr.cc
+++ b/src/pac_expr.cc
@@ -209,6 +209,7 @@ void Expr::GenCaseEval(Output* out_cc, Env* env) {
     foreach (i, CaseExprList, cases_)
         (*i)->value()->ForceIDEval(out_cc, env);
 
+    out_cc->println("// NOLINTBEGIN(bugprone-branch-clone)");
     out_cc->println("switch ( %s ) {", operand_[0]->EvalExpr(out_cc, env));
     Type* switch_type = operand_[0]->DataType(env);
 
@@ -247,6 +248,7 @@ void Expr::GenCaseEval(Output* out_cc, Env* env) {
 
     out_cc->dec_indent();
     out_cc->println("}");
+    out_cc->println("// NOLINTEND(bugprone-branch-clone)");
 
     env->SetEvaluated(val_var);
     str_ = env->RValue(val_var);

--- a/src/pac_expr.cc
+++ b/src/pac_expr.cc
@@ -5,6 +5,7 @@
 #include "pac_exception.h"
 #include "pac_exttype.h"
 #include "pac_id.h"
+#include "pac_nullptr.h"
 #include "pac_number.h"
 #include "pac_output.h"
 #include "pac_record.h"
@@ -64,7 +65,6 @@ Expr::Expr(ID* arg_id) : DataDepElement(EXPR) {
     init();
     expr_type_ = EXPR_ID;
     id_ = arg_id;
-    num_operands_ = 0;
     orig_ = strfmt("%s", id_->Name());
 }
 
@@ -72,15 +72,20 @@ Expr::Expr(Number* arg_num) : DataDepElement(EXPR) {
     init();
     expr_type_ = EXPR_NUM;
     num_ = arg_num;
-    num_operands_ = 0;
     orig_ = strfmt("((int) %s)", num_->Str());
+}
+
+Expr::Expr(Nullptr* arg_nullp) : DataDepElement(EXPR) {
+    init();
+    expr_type_ = EXPR_NULLPTR;
+    nullp_ = arg_nullp;
+    orig_ = strfmt("%s", nullp_->Str());
 }
 
 Expr::Expr(ConstString* cstr) : DataDepElement(EXPR) {
     init();
     expr_type_ = EXPR_CSTR;
     cstr_ = cstr;
-    num_operands_ = 0;
     orig_ = cstr_->str();
 }
 
@@ -88,7 +93,6 @@ Expr::Expr(RegEx* regex) : DataDepElement(EXPR) {
     init();
     expr_type_ = EXPR_REGEX;
     regex_ = regex;
-    num_operands_ = 0;
     orig_ = strfmt("/%s/", regex_->str().c_str());
 }
 
@@ -257,6 +261,7 @@ void Expr::GenCaseEval(Output* out_cc, Env* env) {
 void Expr::GenEval(Output* out_cc, Env* env) {
     switch ( expr_type_ ) {
         case EXPR_NUM: str_ = num_->Str(); break;
+        case EXPR_NULLPTR: str_ = nullp_->Str(); break;
 
         case EXPR_ID:
             if ( ! env->Evaluated(id_) )

--- a/src/pac_expr.def
+++ b/src/pac_expr.def
@@ -1,5 +1,6 @@
 EXPR_DEF(EXPR_ID, 		0, "%s")
 EXPR_DEF(EXPR_NUM,		0, "%s")
+EXPR_DEF(EXPR_NULLPTR,		0, "%s")
 EXPR_DEF(EXPR_CSTR,		0, "%s")
 EXPR_DEF(EXPR_REGEX,		0, "REGEX(%s)")
 EXPR_DEF(EXPR_SUBSCRIPT,	2, "@element@(%s[%s])") 

--- a/src/pac_expr.h
+++ b/src/pac_expr.h
@@ -18,6 +18,7 @@ public:
 
     Expr(ID* id);
     Expr(Number* num);
+    Expr(Nullptr* nullp);
     Expr(ConstString* s);
     Expr(RegEx* regex);
     Expr(ExprList* args); // for EXPR_CALLARGS
@@ -101,6 +102,7 @@ private:
     RegEx* regex_;        // EXPR_REGEX
     ExprList* args_;      // EXPR_CALLARGS
     CaseExprList* cases_; // EXPR_CASE
+    Nullptr* nullp_;      // EXPR_NULLPTR
 
     string str_;  // value string
     string orig_; // original string for debugging info

--- a/src/pac_externtype.def
+++ b/src/pac_externtype.def
@@ -1,4 +1,4 @@
-EXTERNTYPE(bool, bool, NUMBER)
+EXTERNTYPE(bool, bool, BOOLEAN)
 EXTERNTYPE(int, int, NUMBER)
 EXTERNTYPE(double, double, NUMBER)
 EXTERNTYPE(string, string, PLAIN)

--- a/src/pac_exttype.cc
+++ b/src/pac_exttype.cc
@@ -9,7 +9,8 @@ bool ExternType::DefineValueVar() const { return true; }
 string ExternType::DataTypeStr() const {
     switch ( ext_type_ ) {
         case PLAIN:
-        case NUMBER: return id_->Name();
+        case NUMBER:
+        case BOOLEAN: return id_->Name();
         case POINTER: return string(id_->Name()) + " *";
         default: ASSERT(0); return "";
     }
@@ -31,6 +32,8 @@ void ExternType::GenInitCode(Output* out_cc, Env* env) {
         out_cc->println("%s = 0;", env->LValue(value_var()));
     else if ( IsPointerType() )
         out_cc->println("%s = nullptr;", env->LValue(value_var()));
+    else if ( IsBooleanType() )
+        out_cc->println("%s = false;", env->LValue(value_var()));
 
     Type::GenInitCode(out_cc, env);
 }

--- a/src/pac_exttype.h
+++ b/src/pac_exttype.h
@@ -10,7 +10,7 @@
 
 class ExternType : public Type {
 public:
-    enum EXTType { PLAIN, NUMBER, POINTER };
+    enum EXTType { PLAIN, NUMBER, POINTER, BOOLEAN };
     ExternType(const ID* id, EXTType ext_type) : Type(EXTERN), id_(id), ext_type_(ext_type) {}
 
     bool DefineValueVar() const override;
@@ -21,6 +21,7 @@ public:
     string EvalMember(const ID* member_id) const override;
     bool IsNumericType() const override { return ext_type_ == NUMBER; }
     bool IsPointerType() const override { return ext_type_ == POINTER; }
+    bool IsBooleanType() const override { return ext_type_ == BOOLEAN; }
 
     void GenInitCode(Output* out_cc, Env* env) override;
 

--- a/src/pac_nullptr.h
+++ b/src/pac_nullptr.h
@@ -1,0 +1,14 @@
+#ifndef pac_nullptr_h
+#define pac_nullptr_h
+
+#include "pac_common.h"
+
+class Nullptr : public Object {
+public:
+    const char* Str() const { return s.c_str(); }
+
+protected:
+    const string s = "nullptr";
+};
+
+#endif // pac_nullptr_h

--- a/src/pac_parse.yy
+++ b/src/pac_parse.yy
@@ -25,7 +25,7 @@
 %token TOK_EMBEDDED_ATOM TOK_EMBEDDED_STRING
 %token TOK_PAC_VAL TOK_PAC_SET TOK_PAC_TYPE TOK_PAC_TYPEOF TOK_PAC_CONST_DEF
 %token TOK_END_PAC
-%token TOK_EXTERN
+%token TOK_EXTERN TOK_NULLPTR
 
 %nonassoc '=' TOK_PLUSEQ
 %left ';'
@@ -66,6 +66,7 @@
 %type <function> funcproto function
 %type <id> TOK_ID tok_id optfieldid
 %type <input> input
+%type <nullp> TOK_NULLPTR
 %type <num> TOK_NUMBER
 %type <pacprimitive> embedded_pac_primitive
 %type <param> param
@@ -105,6 +106,7 @@
 #include "pac_id.h"
 #include "pac_inputbuf.h"
 #include "pac_let.h"
+#include "pac_nullptr.h"
 #include "pac_output.h"
 #include "pac_param.h"
 #include "pac_paramtype.h"
@@ -160,6 +162,7 @@ extern Output* source_output;
 	InputBuffer		*input;
 	LetFieldList		*letfieldlist;
 	LetField		*letfield;
+	Nullptr			*nullp;
 	Number			*num;
 	PacPrimitive		*pacprimitive;
 	Param 			*param;
@@ -573,6 +576,10 @@ expr		:	tok_id
 				$$ = new Expr($1);
 				}
 		|	TOK_NUMBER
+				{
+				$$ = new Expr($1);
+				}
+		|	TOK_NULLPTR
 				{
 				$$ = new Expr($1);
 				}

--- a/src/pac_record.cc
+++ b/src/pac_record.cc
@@ -100,6 +100,7 @@ void RecordType::DoGenParseCode(Output* out_cc, Env* env, const DataPtr& data, i
         GenBoundaryCheck(out_cc, env, data);
 
     if ( incremental_parsing() ) {
+        out_cc->println("// NOLINTBEGIN(bugprone-branch-clone)");
         out_cc->println("switch ( %s ) {", env->LValue(parsing_state_id));
 
         out_cc->println("case 0:");
@@ -113,6 +114,7 @@ void RecordType::DoGenParseCode(Output* out_cc, Env* env, const DataPtr& data, i
         out_cc->println("%s = true;", env->LValue(parsing_complete_var()));
         out_cc->dec_indent();
         out_cc->println("}");
+        out_cc->println("// NOLINTEND(bugprone-branch-clone)");
     }
     else {
         ASSERT(data.id() == begin_of_data && data.offset() == 0);

--- a/src/pac_scan.ll
+++ b/src/pac_scan.ll
@@ -21,6 +21,7 @@
 #include "pac_expr.h"
 #include "pac_flow.h"
 #include "pac_id.h"
+#include "pac_nullptr.h"
 #include "pac_number.h"
 #include "pac_output.h"
 #include "pac_param.h"
@@ -199,6 +200,10 @@ ESCSEQ	(\\([^\n]|[0-7]{3}|x[[:xdigit:]]{2}))
 <INITIAL>flowunit		{
 				yylval.val = AnalyzerDataUnit::FLOWUNIT;
 				return TOK_DATAUNIT;
+				}
+<INITIAL>nullptr		{
+				yylval.nullp = new Nullptr();
+				return TOK_NULLPTR;
 				}
 <INITIAL>of			return TOK_OF;
 <INITIAL>offsetof 		return TOK_OFFSETOF;

--- a/src/pac_type.cc
+++ b/src/pac_type.cc
@@ -487,6 +487,7 @@ void Type::GenParseBuffer(Output* out_cc, Env* env, int flags) {
 
     if ( attr_length_expr() ) {
         ASSERT(buffer_mode() == BUFFER_BY_LENGTH);
+        out_cc->println("// NOLINTBEGIN(bugprone-branch-clone)");
         out_cc->println("switch ( %s ) {", env->LValue(buffering_state_id));
         out_cc->inc_indent();
         out_cc->println("case 0:");
@@ -537,6 +538,7 @@ void Type::GenParseBuffer(Output* out_cc, Env* env, int flags) {
         out_cc->dec_indent();
         out_cc->dec_indent();
         out_cc->println("}");
+        out_cc->println("// NOLINTEND(bugprone-branch-clone)");
     }
     else if ( attr_restofflow_ ) {
         out_cc->println("BINPAC_ASSERT(%s->eof());", env->RValue(flow_buffer_id));

--- a/src/pac_type.cc
+++ b/src/pac_type.cc
@@ -887,8 +887,8 @@ bool Type::CompatibleTypes(Type* type1, Type* type2) {
 Type* Type::LookUpByID(ID* id) {
     // 1. Is it a pre-defined type?
     string name = id->Name();
-    if ( type_map_.find(name) != type_map_.end() ) {
-        return type_map_[name]->Clone();
+    if ( auto it = type_map_.find(name); it != type_map_.end() ) {
+        return it->second->Clone();
     }
 
     // 2. Is it a simple declared type?

--- a/src/pac_type.h
+++ b/src/pac_type.h
@@ -110,7 +110,7 @@ public:
     // is numeric or pointer)
     string DataTypeConstRefStr() const {
         string data_type = DataTypeStr();
-        if ( ! IsPointerType() && ! IsNumericType() )
+        if ( ! IsPointerType() && ! IsNumericType() && ! IsBooleanType() )
             data_type += " const&";
         return data_type;
     }
@@ -138,6 +138,7 @@ public:
 
     virtual bool IsPointerType() const = 0;
     virtual bool IsNumericType() const { return false; }
+    virtual bool IsBooleanType() const { return false; }
     bool IsEmptyType() const;
 
     ////////////////////////////////////////

--- a/src/pac_type.h
+++ b/src/pac_type.h
@@ -1,7 +1,9 @@
 #ifndef pac_type_h
 #define pac_type_h
 
+#include <cstdint>
 #include <map>
+
 using namespace std;
 
 #include "pac_common.h"
@@ -10,7 +12,7 @@ using namespace std;
 
 class Type : public Object, public DataDepElement {
 public:
-    enum TypeType {
+    enum TypeType : int8_t {
         UNDEF = -1,
         EMPTY,
         BUILTIN,
@@ -200,7 +202,7 @@ public:
     bool BufferableWithLineBreaker() const;
     Expr* LineBreaker() const;
 
-    enum BufferMode {
+    enum BufferMode : uint8_t {
         NOT_BUFFERABLE,
         BUFFER_NOTHING, // for type "empty"
         BUFFER_BY_LENGTH,
@@ -236,20 +238,21 @@ protected:
     virtual Type* DoClone() const = 0;
 
 protected:
-    TypeType tot_;
     const TypeDecl* type_decl_;
-    bool declared_as_type_;
     const ID* type_decl_id_;
     Env* env_;
 
     const ID* value_var_;
+
     bool anonymous_value_var_; // whether the ID is anonymous
+    bool declared_as_type_;
+    bool boundary_checked_;
+    TypeType tot_;
 
     string data_id_str_;
     int value_var_type_;
     Field* size_var_field_;
     char* size_expr_;
-    bool boundary_checked_;
     string lvalue_;
     FieldList* fields_;
 
@@ -278,13 +281,13 @@ protected:
     Expr* attr_byteorder_expr_;
     ExprList* attr_checks_;
     ExprList* attr_enforces_;
-    bool attr_chunked_;
-    bool attr_exportsourcedata_;
     Expr* attr_if_expr_;
     Expr* attr_length_expr_;
     FieldList* attr_letfields_;
     Expr* attr_multiline_end_;
     Expr* attr_linebreaker_;
+    bool attr_chunked_;
+    bool attr_exportsourcedata_;
     bool attr_oneline_;
     bool attr_refcount_;
     ExprList* attr_requires_;


### PR DESCRIPTION
This PR fixes some issues reported by clang-tidy when running against the generated code for Zeek.

1. The `switch` statements generated by Binpac almost always have cloned branches. These are mostly single break statements. Instead of trying to fix the code gen, just wrap those blocks in `NOLINT` statements to prevent clang-tidy on Zeek builds from spewing a ton of warnings for these.

2. Changes `bool` from being a number underneath to being an actual Boolean type that can be mapped to true/false in c++. This fixes some findings where were having to cast true/false to integers.

3. Adds a `nullptr` keyword for allowing comparisons in Binpac code that would get converted into integer comparisons in the generated code.