### PR TITLE
More fixes to clang-tidy findings in generated code

### DIFF
--- a/lib/binpac_analyzer.h
+++ b/lib/binpac_analyzer.h
@@ -8,14 +8,14 @@ namespace binpac {
 // The interface for a connection analyzer
 class ConnectionAnalyzer {
 public:
-    virtual ~ConnectionAnalyzer() {}
+    virtual ~ConnectionAnalyzer() = default;
     virtual void NewData(bool is_orig, const unsigned char* begin_of_data, const unsigned char* end_of_data) = 0;
 };
 
 // The interface for a flow analyzer
 class FlowAnalyzer {
 public:
-    virtual ~FlowAnalyzer() {}
+    virtual ~FlowAnalyzer() = default;
     virtual void NewData(const unsigned char* begin_of_data, const unsigned char* end_of_data) = 0;
 };
 

--- a/src/pac_conn.cc
+++ b/src/pac_conn.cc
@@ -110,7 +110,7 @@ void ConnDecl::GenGapFunc(Output* out_h, Output* out_cc) {
 void ConnDecl::GenProcessFunc(Output* out_h, Output* out_cc) {
     string proto = strfmt("%s(bool is_orig, const_byteptr begin, const_byteptr end)", kNewData);
 
-    out_h->println("void %s;", proto.c_str());
+    out_h->println("void %s override;", proto.c_str());
 
     out_cc->println("void %s::%s {", class_name().c_str(), proto.c_str());
     out_cc->inc_indent();

--- a/src/pac_enum.cc
+++ b/src/pac_enum.cc
@@ -41,6 +41,7 @@ void EnumDecl::Prepare() {
 }
 
 void EnumDecl::GenForwardDeclaration(Output* out_h) {
+    out_h->println("// NOLINTNEXTLINE(performance-enum-size)");
     out_h->println("enum %s {", id_->Name());
     out_h->inc_indent();
     int c = 0;

--- a/src/pac_flow.cc
+++ b/src/pac_flow.cc
@@ -151,7 +151,7 @@ void FlowDecl::GenProcessFunc(Output* out_h, Output* out_cc) {
     string proto = strfmt("%s(const_byteptr %s, const_byteptr %s)", kNewData, env_->LValue(begin_of_data),
                           env_->LValue(end_of_data));
 
-    out_h->println("void %s;", proto.c_str());
+    out_h->println("void %s override;", proto.c_str());
 
     out_cc->println("void %s::%s {", class_name().c_str(), proto.c_str());
     out_cc->inc_indent();

--- a/src/pac_typedecl.cc
+++ b/src/pac_typedecl.cc
@@ -178,9 +178,15 @@ void TypeDecl::GenConstructorFunc(Output* out_h, Output* out_cc) {
 }
 
 void TypeDecl::GenDestructorFunc(Output* out_h, Output* out_cc) {
+    vector<string> base_classes;
+    AddBaseClass(&base_classes);
+
     string proto = strfmt("~%s()", class_name().c_str());
 
-    out_h->println("%s;", proto.c_str());
+    if ( base_classes.empty() )
+        out_h->println("%s;", proto.c_str());
+    else
+        out_h->println("%s override;", proto.c_str());
 
     out_cc->println("%s::%s {", class_name().c_str(), proto.c_str());
     out_cc->inc_indent();


### PR DESCRIPTION
- Add `NOLINT` directives for enums in generated code. We're never going to go through and set sizes for all of these.
- Add `override` to virtual methods in generated code. This also adds `= default` to a few destructors that didn't have bodies in the binpac code itself.