### PR TITLE
Require C++20 for builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.15.0 FATAL_ERROR)
 project(BinPAC C CXX)
 include(cmake/CommonCMakeConfig.cmake)
+include(cmake/RequireCXXStd.cmake)
 
 file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/VERSION" BINPAC_VERSION LIMIT_COUNT 1)
 string(REPLACE "." " " _version_numbers ${BINPAC_VERSION})

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -14,11 +14,9 @@ set(binpac_lib_SRCS binpac_buffer.cc binpac_bytestring.cc binpac_regex.cc ${binp
 
 if (ENABLE_SHARED)
     add_library(binpac_lib SHARED ${binpac_lib_SRCS})
-    target_compile_features(binpac_lib PRIVATE cxx_std_17)
     set_target_properties(
         binpac_lib
-        PROPERTIES CXX_EXTENSIONS OFF
-                   SOVERSION ${BINPAC_SOVERSION}
+        PROPERTIES SOVERSION ${BINPAC_SOVERSION}
                    VERSION ${BINPAC_VERSION_MAJOR}.${BINPAC_VERSION_MINOR}
                    MACOSX_RPATH true
                    OUTPUT_NAME binpac)
@@ -27,8 +25,7 @@ endif ()
 
 if (ENABLE_STATIC)
     add_library(binpac_static STATIC ${binpac_lib_SRCS})
-    target_compile_features(binpac_static PRIVATE cxx_std_17)
-    set_target_properties(binpac_static PROPERTIES CXX_EXTENSIONS OFF OUTPUT_NAME binpac)
+    set_target_properties(binpac_static PROPERTIES OUTPUT_NAME binpac)
     install(TARGETS binpac_static DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif ()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,9 +99,9 @@ set(binpac_SRCS
     pac_varfield.h
     pac_withinput.h)
 
+include(${PROJECT_SOURCE_DIR}/cmake/RequireCXXStd.cmake)
+
 add_executable(binpac ${binpac_SRCS})
-target_compile_features(binpac PRIVATE cxx_std_17)
-set_target_properties(binpac PROPERTIES CXX_EXTENSIONS OFF)
 
 if (MSVC)
     # If building separately from zeek, we need to add the libunistd subdirectory


### PR DESCRIPTION
This bumps the cmake submodule to a version that requires C++20 and makes a few other minor changes to use that.