### PR TITLE
Fix clang-tidy readability-isolate-declaration finding in generated code

### DIFF
--- a/src/pac_inputbuf.cc
+++ b/src/pac_inputbuf.cc
@@ -20,8 +20,8 @@ DataPtr InputBuffer::GenDataBeginEnd(Output* out_cc, Env* env) {
     env->AddID(begin_of_data, TEMP_VAR, extern_type_const_byteptr);
     env->AddID(end_of_data, TEMP_VAR, extern_type_const_byteptr);
 
-    out_cc->println("%s %s, %s;", extern_type_const_byteptr->DataTypeStr().c_str(), env->LValue(begin_of_data),
-                    env->LValue(end_of_data));
+    out_cc->println("%s %s;", extern_type_const_byteptr->DataTypeStr().c_str(), env->LValue(begin_of_data));
+    out_cc->println("%s %s;", extern_type_const_byteptr->DataTypeStr().c_str(), env->LValue(end_of_data));
 
     out_cc->println("get_pointers(%s, &%s, &%s);", expr_->EvalExpr(out_cc, env), env->LValue(begin_of_data),
                     env->LValue(end_of_data));


### PR DESCRIPTION
This fixes this finding in a few binpac analyzers:

```
/Users/tim/Desktop/projects/zeek-master/build/src/analyzer/protocol/gssapi/gssapi_pac.cc:846:9: error: multiple declarations in a single statement reduces readability [readability-isolate-declaration,-warnings-as-errors]
  846 |         const_byteptr t_begin_of_data, t_end_of_data;
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/tim/Desktop/projects/zeek-master/build/src/analyzer/protocol/gssapi/gssapi_pac.cc:862:9: error: multiple declarations in a single statement reduces readability [readability-isolate-declaration,-warnings-as-errors]
  862 |         const_byteptr t_begin_of_data, t_end_of_data;
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
8416 warnings generated.
```

Related to https://github.com/zeek/zeek/pull/4612