### PR TITLE
Coverity fixes

### DIFF
--- a/src/pac_datadep.cc
+++ b/src/pac_datadep.cc
@@ -49,6 +49,8 @@ void RequiresAnalyzerContext::ProcessExpr(Expr* expr) {
 
 bool RequiresAnalyzerContext::compute(DataDepElement* element) {
     RequiresAnalyzerContext visitor;
-    element->Traverse(&visitor);
+    // This result is intentionally ignored. We want to traverse, but always return
+    // the same result.
+    std::ignore = element->Traverse(&visitor);
     return visitor.requires_analyzer_context_;
 }

--- a/src/pac_expr.h
+++ b/src/pac_expr.h
@@ -1,6 +1,8 @@
 #ifndef pac_expr_h
 #define pac_expr_h
 
+#include <cstdint>
+
 #include "pac_common.h"
 #include "pac_datadep.h"
 
@@ -8,7 +10,7 @@ class CaseExpr;
 
 class Expr : public Object, public DataDepElement {
 public:
-    enum ExprType {
+    enum ExprType : uint8_t {
 #define EXPR_DEF(type, x, y) type,
 #include "pac_expr.def"
 #undef EXPR_DEF
@@ -93,16 +95,16 @@ protected:
 private:
     ExprType expr_type_;
 
-    int num_operands_;
-    Expr* operand_[3];
+    int num_operands_ = 0;
+    Expr* operand_[3] = {nullptr};
 
-    ID* id_;              // EXPR_ID
-    Number* num_;         // EXPR_NUM
-    ConstString* cstr_;   // EXPR_CSTR
-    RegEx* regex_;        // EXPR_REGEX
-    ExprList* args_;      // EXPR_CALLARGS
-    CaseExprList* cases_; // EXPR_CASE
-    Nullptr* nullp_;      // EXPR_NULLPTR
+    ID* id_ = nullptr;              // EXPR_ID
+    Number* num_ = nullptr;         // EXPR_NUM
+    ConstString* cstr_ = nullptr;   // EXPR_CSTR
+    RegEx* regex_ = nullptr;        // EXPR_REGEX
+    ExprList* args_ = nullptr;      // EXPR_CALLARGS
+    CaseExprList* cases_ = nullptr; // EXPR_CASE
+    Nullptr* nullp_ = nullptr;      // EXPR_NULLPTR
 
     string str_;  // value string
     string orig_; // original string for debugging info

--- a/src/pac_main.cc
+++ b/src/pac_main.cc
@@ -38,7 +38,7 @@ void add_to_include_directories(string dirs) {
         if ( dir.length() > 0 && *(dir.end() - 1) != '/' )
             dir += '/';
 
-        FLAGS_include_directories.push_back(dir);
+        FLAGS_include_directories.push_back(std::move(dir));
         dir_begin = dir_end + 1;
     }
 }


### PR DESCRIPTION
This PR cleans some Coverity findings for binpac out of the list. The pac_expr commit is 9 of the same warning repeated.